### PR TITLE
ci: regenerate demo.gif on main, pin Go via go.mod

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -1,0 +1,47 @@
+name: Demo
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'demo.tape'
+      - 'cmd/**'
+      - 'internal/**'
+      - 'pkg/**'
+      - 'scripts/gen_demo_certs.go'
+      - '.github/workflows/demo.yml'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: demo-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  render:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Render demo.gif
+        uses: charmbracelet/vhs-action@v2
+        with:
+          path: demo.tape
+
+      - name: Commit and push if demo.gif changed
+        run: |
+          if git diff --quiet -- demo.gif; then
+            echo "demo.gif unchanged, nothing to commit"
+            exit 0
+          fi
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add demo.gif
+          git commit -m "chore(demo): refresh demo.gif"
+          git push

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,9 @@ name: Test
 on:
   push:
     branches: [ main ]
+    paths-ignore:
+      - 'demo.gif'
+      - 'README.md'
   pull_request:
     branches: [ main ]
 
@@ -16,7 +19,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.25.6'
+        go-version-file: go.mod
 
     - name: Download dependencies
       run: go mod download


### PR DESCRIPTION
## Summary

- Adds a \`Demo\` workflow that re-renders \`demo.gif\` via [charmbracelet/vhs-action](https://github.com/charmbracelet/vhs-action) on every \`main\` push that touches \`demo.tape\` or any of the source paths the tape exercises (\`cmd/\`, \`internal/\`, \`pkg/\`, \`scripts/gen_demo_certs.go\`). The job commits and pushes \`demo.gif\` back when it changes.
- Pins the \`Test\` workflow's Go version to \`go-version-file: go.mod\` instead of the literal \`'1.25.6'\`. This unblocks dependabot PR #15 (\`actions/setup-go\` v5 → v6), which started failing because v6 sets \`GOTOOLCHAIN=local\` and the workflow could no longer auto-download the toolchain required by \`go.mod\`.
- Adds \`paths-ignore: [demo.gif, README.md]\` to the test workflow so the demo workflow's auto-commits don't burn a second CI run.

## How the loop is prevented

Pushes made with the default \`GITHUB_TOKEN\` do not trigger other workflows ([docs](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow)). The \`paths-ignore\` is belt-and-suspenders.

## Test plan

- [ ] Merge → confirm the Demo workflow runs and the post-merge commit (if any) shows up as github-actions[bot]
- [ ] Verify the bot's \`chore(demo): refresh demo.gif\` commit does NOT trigger the Test workflow
- [ ] Rebase #15 (or wait for dependabot to refresh it) and confirm setup-go@v6 now passes