### PR TITLE
ci(demo): install vhs deps directly to fix ffmpeg failure

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -29,10 +29,20 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Install ffmpeg
+        run: sudo apt-get update && sudo apt-get install -y ffmpeg
+
+      - name: Install ttyd
+        run: |
+          curl -L -o /tmp/ttyd https://github.com/tsl0922/ttyd/releases/latest/download/ttyd.x86_64
+          chmod +x /tmp/ttyd
+          sudo mv /tmp/ttyd /usr/local/bin/ttyd
+
+      - name: Install vhs
+        run: go install github.com/charmbracelet/vhs@latest
+
       - name: Render demo.gif
-        uses: charmbracelet/vhs-action@v2
-        with:
-          path: demo.tape
+        run: vhs demo.tape
 
       - name: Commit and push if demo.gif changed
         run: |


### PR DESCRIPTION
## Summary

Replaces \`charmbracelet/vhs-action@v2\` with explicit installs for the
three things vhs needs: \`ffmpeg\` (apt), \`ttyd\` (upstream release
binary), and \`vhs\` itself (\`go install\`).

The action's bundled ffmpeg fetcher has been failing on \`ubuntu-latest\`
with \`Failed to install ffmpeg\`, which broke the demo workflow added
in PR #17 the moment it landed on main.

The tape doesn't pin a font name, so the action's font setup isn't
needed either — \`vhs\` falls back to the system monospace.

## Test plan

- [ ] After merge, the next main push that touches \`demo.tape\` /
      \`internal/**\` / \`pkg/**\` / \`cmd/**\` should run the Demo
      workflow to completion and either commit a refreshed
      \`demo.gif\` or no-op if unchanged.