### PR TITLE
fix(ci): bump go to 1.26.4 to clear GO-2026-5037

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kanywst/y509
 
-go 1.26.2
+go 1.26.4
 
 tool (
 	github.com/golangci/golangci-lint/cmd/golangci-lint


### PR DESCRIPTION
## What

Bump the `go` directive in `go.mod` from 1.26.2 to 1.26.4.

## Why

CI's `make vulncheck` step started failing on `main` (and on any open PR, e.g. #20) with:

```text
Vulnerability #1: GO-2026-5037
  Inefficient candidate hostname parsing in crypto/x509
  Found in: crypto/x509@go1.26.2
  Fixed in: crypto/x509@go1.26.4
  #1: pkg/certificate/certificate.go:532:26: ValidateChain calls x509.Certificate.Verify
  #2: internal/cmd/root.go:53:27: ... x509.HostnameError.Error
```

This is a Go standard-library vuln, fixed in go1.26.4. `setup-go` installs the toolchain from `go.mod` via `go-version-file`, so bumping the directive is enough to pick up the fixed stdlib.

## Verification

Locally on go1.26.4:

- `go tool govulncheck ./...` → No vulnerabilities found (exit 0)
- `go build ./...` → OK

Unblocks #20 once it's rebased onto main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go toolchain version to 1.26.4 with associated updates and improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->