### PR TITLE
ci(release): bump attest-build-provenance to v4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
       # SLSA build provenance for the release archives and packages.
       # Verify with: gh attestation verify <artifact> -R kanywst/y509
       - name: Attest build provenance
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@v4
         with:
           subject-path: |
             dist/*.tar.gz


### PR DESCRIPTION
`actions/attest-build-provenance` was pinned at `@v2` (two majors behind; current is v4). v4 is a thin wrapper over `actions/attest` with the same `subject-path` interface, so this is a drop-in bump. Worth doing before the first real release that exercises the provenance step.

No functional change to the build; release pipeline validated locally with `goreleaser check` and a `--snapshot` build (4 targets + archives + deb/rpm + checksums + cask all succeed).