### PR TITLE
fix(release): build static binaries with CGO_ENABLED=0

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,6 +5,9 @@ project_name: y509
 builds:
   - binary: y509
     main: ./cmd/y509
+    # Static link (pure-Go net resolver) so the binary runs on any glibc (#26).
+    env:
+      - CGO_ENABLED=0
     goos:
       - darwin
       - linux


### PR DESCRIPTION
Closes #26

The release linux/amd64 build defaulted to CGO_ENABLED=1, so the net package linked glibc dynamically. The binary then required GLIBC_2.32/2.34 and failed to start on Debian 11 (glibc 2.31).

Set CGO_ENABLED=0 to link statically with the pure-Go resolver. Runs on any glibc.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to improve application compatibility and ensure consistent behavior across different system environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->