### PR TITLE
Register each subcommand only once

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -62,11 +62,7 @@ func init() {
 	RootCmd.PersistentFlags().String("log-file", "", "Path to the log file")
 	RootCmd.PersistentFlags().Bool("debug", false, "Enable debug logging")
 
-	// Add subcommands
-	RootCmd.AddCommand(validateCmd)
-	RootCmd.AddCommand(exportCmd)
-	RootCmd.AddCommand(versionCmd)
-	RootCmd.AddCommand(completionCmd)
+	// Subcommands register themselves in their own init().
 
 	// Handle arguments
 	RootCmd.Args = func(_ *cobra.Command, args []string) error {


### PR DESCRIPTION
`--help` listed every subcommand twice. They were registered in `root.go`'s `init()` and again in each command file's own `init()`.

Removed the duplicate registration block in `root.go` so each command registers itself once.

Before:
```
completion  Generate shell completion scripts
completion  Generate shell completion scripts
export      Export a certificate to a file
export      Export a certificate to a file
...
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured CLI command initialization architecture to improve code organization and modularity. Commands now manage their own registration independently, enhancing code maintainability and separation of concerns. No impact on user-facing functionality or command behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->