### PR TITLE
Print version to stdout

### DIFF
--- a/internal/cmd/version.go
+++ b/internal/cmd/version.go
@@ -2,20 +2,19 @@
 package cmd
 
 import (
-	"github.com/kanywst/y509/internal/logger"
+	"fmt"
+
 	"github.com/kanywst/y509/internal/version"
 	"github.com/spf13/cobra"
-	"go.uber.org/zap"
 )
 
 // versionCmd represents the version command
 var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print the version number",
-	Run: func(_ *cobra.Command, _ []string) {
-		logger.Log.Info("Version information",
-			zap.String("version", version.GetVersion()),
-			zap.String("build", version.GetFullVersion()))
+	Run: func(cmd *cobra.Command, _ []string) {
+		fmt.Fprintf(cmd.OutOrStdout(), "y509 version %s\nBuild: %s\n",
+			version.GetVersion(), version.GetFullVersion())
 	},
 }
 

--- a/internal/cmd/version.go
+++ b/internal/cmd/version.go
@@ -12,6 +12,9 @@ import (
 var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print the version number",
+	// A write failure is an I/O error, not a usage error, so don't dump
+	// the help text on top of it.
+	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		_, err := fmt.Fprintf(cmd.OutOrStdout(), "y509 version %s\nBuild: %s\n",
 			version.GetVersion(), version.GetFullVersion())

--- a/internal/cmd/version.go
+++ b/internal/cmd/version.go
@@ -12,9 +12,10 @@ import (
 var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print the version number",
-	Run: func(cmd *cobra.Command, _ []string) {
-		fmt.Fprintf(cmd.OutOrStdout(), "y509 version %s\nBuild: %s\n",
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		_, err := fmt.Fprintf(cmd.OutOrStdout(), "y509 version %s\nBuild: %s\n",
 			version.GetVersion(), version.GetFullVersion())
+		return err
 	},
 }
 


### PR DESCRIPTION
`y509 version` printed nothing. It logged through the zap logger, which writes to a log file (`$TMPDIR/y509.log`), not the terminal.

Now it writes the version and build info to stdout:

```
y509 version dev
Build: dev
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in the version command to properly report and propagate errors without extraneous output.

* **Refactor**
  * Optimized the version command's output mechanism for cleaner execution and direct display of version information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->