### PR TITLE
Fix CRT export and stop leaving empty files

### DIFF
--- a/internal/cmd/export.go
+++ b/internal/cmd/export.go
@@ -16,7 +16,7 @@ var exportCmd = &cobra.Command{
 	Use:   "export [index] [format] [filename]",
 	Short: "Export a certificate to a file",
 	Long: `Export a certificate to a file in the specified format.
-Format can be 'pem', 'der', or 'crt' (crt is written as PEM).
+Format can be 'pem', 'der', 'crt', or 'cert' (crt and cert are written as PEM).
 If no index is provided, the currently selected certificate will be exported.
 If no format is provided, 'pem' will be used.
 If no filename is provided, a default name will be generated.`,

--- a/internal/cmd/export.go
+++ b/internal/cmd/export.go
@@ -16,7 +16,7 @@ var exportCmd = &cobra.Command{
 	Use:   "export [index] [format] [filename]",
 	Short: "Export a certificate to a file",
 	Long: `Export a certificate to a file in the specified format.
-Format can be either 'pem' or 'der'.
+Format can be 'pem', 'der', or 'crt' (crt is written as PEM).
 If no index is provided, the currently selected certificate will be exported.
 If no format is provided, 'pem' will be used.
 If no filename is provided, a default name will be generated.`,

--- a/pkg/certificate/certificate.go
+++ b/pkg/certificate/certificate.go
@@ -565,6 +565,30 @@ func FormatChainValidation(result *ValidationResult) string {
 
 // ExportCertificate exports a certificate to a file
 func ExportCertificate(cert *x509.Certificate, format string, filename string) error {
+	// Determine format from argument or extension
+	f := strings.ToLower(format)
+	if f == "" {
+		ext := filepath.Ext(filename)
+		if ext != "" {
+			f = ext[1:] // remove dot
+		}
+	}
+
+	// Build the file contents before touching the filesystem so an
+	// unsupported format doesn't leave an empty file behind.
+	var data []byte
+	switch f {
+	case "pem", "crt", "cert":
+		data = pem.EncodeToMemory(&pem.Block{
+			Type:  "CERTIFICATE",
+			Bytes: cert.Raw,
+		})
+	case "der":
+		data = cert.Raw
+	default:
+		return fmt.Errorf("unsupported format: %s (supported: pem, der, crt)", f)
+	}
+
 	// Create directory if it doesn't exist
 	dir := filepath.Dir(filename)
 	if dir != "." {
@@ -573,7 +597,6 @@ func ExportCertificate(cert *x509.Certificate, format string, filename string) e
 		}
 	}
 
-	// Open file for writing
 	file, err := os.Create(filename)
 	if err != nil {
 		return fmt.Errorf("failed to create file: %v", err)
@@ -584,31 +607,8 @@ func ExportCertificate(cert *x509.Certificate, format string, filename string) e
 		}
 	}()
 
-	// Determine format from argument or extension
-	f := strings.ToLower(format)
-	if f == "" {
-		ext := filepath.Ext(filename)
-		if ext != "" {
-			f = ext[1:] // remove dot
-		}
-	}
-
-	// Export based on format
-	switch f {
-	case "pem":
-		block := &pem.Block{
-			Type:  "CERTIFICATE",
-			Bytes: cert.Raw,
-		}
-		if err := pem.Encode(file, block); err != nil {
-			return fmt.Errorf("failed to encode PEM: %v", err)
-		}
-	case "der":
-		if _, err := file.Write(cert.Raw); err != nil {
-			return fmt.Errorf("failed to write DER: %v", err)
-		}
-	default:
-		return fmt.Errorf("unsupported format: %s (supported: pem, der)", f)
+	if _, err := file.Write(data); err != nil {
+		return fmt.Errorf("failed to write %s: %v", f, err)
 	}
 
 	return nil

--- a/pkg/certificate/certificate.go
+++ b/pkg/certificate/certificate.go
@@ -565,6 +565,10 @@ func FormatChainValidation(result *ValidationResult) string {
 
 // ExportCertificate exports a certificate to a file
 func ExportCertificate(cert *x509.Certificate, format string, filename string) error {
+	if cert == nil {
+		return fmt.Errorf("certificate is nil")
+	}
+
 	// Determine format from argument or extension
 	f := strings.ToLower(format)
 	if f == "" {
@@ -586,7 +590,7 @@ func ExportCertificate(cert *x509.Certificate, format string, filename string) e
 	case "der":
 		data = cert.Raw
 	default:
-		return fmt.Errorf("unsupported format: %s (supported: pem, der, crt)", f)
+		return fmt.Errorf("unsupported format: %s (supported: pem, der, crt, cert)", f)
 	}
 
 	// Create directory if it doesn't exist

--- a/pkg/certificate/certificate.go
+++ b/pkg/certificate/certificate.go
@@ -565,8 +565,8 @@ func FormatChainValidation(result *ValidationResult) string {
 
 // ExportCertificate exports a certificate to a file
 func ExportCertificate(cert *x509.Certificate, format string, filename string) error {
-	if cert == nil {
-		return fmt.Errorf("certificate is nil")
+	if cert == nil || len(cert.Raw) == 0 {
+		return fmt.Errorf("certificate has no raw data to export")
 	}
 
 	// Determine format from argument or extension

--- a/pkg/certificate/certificate.go
+++ b/pkg/certificate/certificate.go
@@ -574,7 +574,7 @@ func ExportCertificate(cert *x509.Certificate, format string, filename string) e
 	if f == "" {
 		ext := filepath.Ext(filename)
 		if ext != "" {
-			f = ext[1:] // remove dot
+			f = strings.ToLower(ext[1:]) // remove dot, normalize case
 		}
 	}
 

--- a/pkg/certificate/certificate_test.go
+++ b/pkg/certificate/certificate_test.go
@@ -773,6 +773,19 @@ func TestExportCertificate(t *testing.T) {
 	}
 }
 
+func TestExportCertificateUppercaseExtension(t *testing.T) {
+	cert := createTestCert()
+	target := filepath.Join(t.TempDir(), "out.PEM")
+
+	// Empty format means the extension decides; an uppercase one must work.
+	if err := ExportCertificate(cert, "", target); err != nil {
+		t.Fatalf("uppercase extension should be accepted, got: %v", err)
+	}
+	if _, err := os.Stat(target); err != nil {
+		t.Errorf("expected file to be written: %v", err)
+	}
+}
+
 func TestExportCertificateUnsupportedLeavesNoFile(t *testing.T) {
 	cert := createTestCert()
 	target := filepath.Join(t.TempDir(), "out.xyz")

--- a/pkg/certificate/certificate_test.go
+++ b/pkg/certificate/certificate_test.go
@@ -13,6 +13,7 @@ import (
 	"math/big"
 	"net"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -735,6 +736,11 @@ func TestExportCertificate(t *testing.T) {
 			expectError: false,
 		},
 		{
+			name:        "CRT format",
+			format:      "crt",
+			expectError: false,
+		},
+		{
 			name:        "Invalid format",
 			format:      "invalid",
 			expectError: true,
@@ -764,6 +770,18 @@ func TestExportCertificate(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestExportCertificateUnsupportedLeavesNoFile(t *testing.T) {
+	cert := createTestCert()
+	target := filepath.Join(t.TempDir(), "out.xyz")
+
+	if err := ExportCertificate(cert, "xyz", target); err == nil {
+		t.Fatal("expected error for unsupported format, got nil")
+	}
+	if _, err := os.Stat(target); !os.IsNotExist(err) {
+		t.Errorf("unsupported format left a file behind: %v", err)
 	}
 }
 


### PR DESCRIPTION
Two problems in certificate export:

- The export form offered a CRT option, but `ExportCertificate` only handled `pem` and `der`. Picking CRT failed with `unsupported format: crt`.
- The output file was created before the format was validated, so any unsupported format left a zero-byte file behind.

The contents are now built before any file is created, and the file is only opened once the format is known to be valid. `crt` and `cert` are written as PEM.

Added a test for CRT and one that checks no file is left when the format is unsupported.