### PR TITLE
Stop the certificate package logging to stderr

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -41,6 +41,7 @@ var (
 				fmt.Fprintf(os.Stderr, "Failed to initialize logger: %v\n", err)
 				os.Exit(1)
 			}
+			certificate.SetLogger(logger.Log)
 		},
 	}
 )

--- a/pkg/certificate/certificate.go
+++ b/pkg/certificate/certificate.go
@@ -24,13 +24,15 @@ import (
 	"go.uber.org/zap"
 )
 
-var logger *zap.Logger
+// logger defaults to a no-op so the package stays quiet (and never writes
+// to stderr, which would corrupt the TUI). The application wires in its own
+// logger via SetLogger.
+var logger = zap.NewNop()
 
-func init() {
-	var err error
-	logger, err = zap.NewProduction()
-	if err != nil {
-		panic(fmt.Sprintf("failed to initialize logger: %v", err))
+// SetLogger routes the package's diagnostics through the given logger.
+func SetLogger(l *zap.Logger) {
+	if l != nil {
+		logger = l
 	}
 }
 

--- a/pkg/certificate/certificate.go
+++ b/pkg/certificate/certificate.go
@@ -19,15 +19,30 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"go.uber.org/zap"
 )
 
+// safeLogger holds the package logger behind an atomic pointer so SetLogger
+// can be called concurrently with the logging calls without a data race.
+type safeLogger struct {
+	l atomic.Pointer[zap.Logger]
+}
+
+func (s *safeLogger) Info(msg string, fields ...zap.Field)  { s.l.Load().Info(msg, fields...) }
+func (s *safeLogger) Warn(msg string, fields ...zap.Field)  { s.l.Load().Warn(msg, fields...) }
+func (s *safeLogger) Error(msg string, fields ...zap.Field) { s.l.Load().Error(msg, fields...) }
+
 // logger defaults to a no-op so the package stays quiet (and never writes
 // to stderr, which would corrupt the TUI). The application wires in its own
 // logger via SetLogger.
-var logger = zap.NewNop()
+var logger = func() *safeLogger {
+	s := &safeLogger{}
+	s.l.Store(zap.NewNop())
+	return s
+}()
 
 // SetLogger routes the package's diagnostics through the given logger.
 // Passing nil resets it to a no-op logger.
@@ -35,7 +50,7 @@ func SetLogger(l *zap.Logger) {
 	if l == nil {
 		l = zap.NewNop()
 	}
-	logger = l
+	logger.l.Store(l)
 }
 
 // ValidationStatus represents the validation status of a single certificate in the chain.

--- a/pkg/certificate/certificate.go
+++ b/pkg/certificate/certificate.go
@@ -30,10 +30,12 @@ import (
 var logger = zap.NewNop()
 
 // SetLogger routes the package's diagnostics through the given logger.
+// Passing nil resets it to a no-op logger.
 func SetLogger(l *zap.Logger) {
-	if l != nil {
-		logger = l
+	if l == nil {
+		l = zap.NewNop()
 	}
+	logger = l
 }
 
 // ValidationStatus represents the validation status of a single certificate in the chain.


### PR DESCRIPTION
`pkg/certificate` created its own `zap.NewProduction()` logger in `init()`. That logger writes to stderr and ignores the `--log-file`/`--debug` flags, so:

- diagnostics never reached the configured log file, and
- a stray write during the TUI session could corrupt the screen.

The package now defaults to a no-op logger and exposes `SetLogger`, which the app calls after setting up its own logger so everything goes to the same place.