### PR TITLE
Show expiring-soon in the list status icon

### DIFF
--- a/internal/model/list_item.go
+++ b/internal/model/list_item.go
@@ -39,7 +39,7 @@ func (d certDelegate) Update(_ tea.Msg, _ *list.Model) tea.Cmd { return nil }
 
 func (d certDelegate) Render(w io.Writer, m list.Model, index int, item list.Item) {
 	ci, ok := item.(certItem)
-	if !ok {
+	if !ok || ci.info == nil || ci.info.Certificate == nil {
 		return
 	}
 

--- a/internal/model/list_item.go
+++ b/internal/model/list_item.go
@@ -51,7 +51,7 @@ func (d certDelegate) Render(w io.Writer, m list.Model, index int, item list.Ite
 		subjectWidth = 10
 	}
 
-	statusIcon, statusStyle := getStatusIconAndStyle(ci.info, d.styles)
+	statusIcon, statusStyle := getStatusIconAndStyle(ci.info, d.styles, d.warnDays)
 	expiresStr := renderExpiryWithBar(ci.info, d.styles, d.warnDays)
 
 	var baseStyle lipgloss.Style

--- a/internal/model/view.go
+++ b/internal/model/view.go
@@ -378,6 +378,9 @@ func (m Model) renderChainPosition(current *certificate.Info) string {
 }
 
 func getStatusIconAndStyle(certInfo *certificate.Info, styles Styles, warnDays int) (string, lipgloss.Style) {
+	if certInfo == nil {
+		return "", lipgloss.NewStyle()
+	}
 	switch certInfo.ValidationStatus {
 	case certificate.StatusWarning:
 		return "▲", styles.StatusWarning

--- a/internal/model/view.go
+++ b/internal/model/view.go
@@ -377,7 +377,7 @@ func (m Model) renderChainPosition(current *certificate.Info) string {
 	return t.Render()
 }
 
-func getStatusIconAndStyle(certInfo *certificate.Info, styles Styles) (string, lipgloss.Style) {
+func getStatusIconAndStyle(certInfo *certificate.Info, styles Styles, warnDays int) (string, lipgloss.Style) {
 	switch certInfo.ValidationStatus {
 	case certificate.StatusWarning:
 		return "▲", styles.StatusWarning
@@ -386,6 +386,11 @@ func getStatusIconAndStyle(certInfo *certificate.Info, styles Styles) (string, l
 	case certificate.StatusMismatchedIssuer, certificate.StatusInvalidSignature:
 		return "◆", styles.StatusExpired
 	default:
+		// Otherwise valid, but flag it if it expires within the warning
+		// window so the icon matches the expiry bar and the Validity tab.
+		if certInfo.Certificate != nil && certificate.IsExpiringSoonWithin(certInfo.Certificate, warnDays) {
+			return "▲", styles.StatusWarning
+		}
 		return "●", styles.StatusValid
 	}
 }

--- a/internal/model/view.go
+++ b/internal/model/view.go
@@ -389,9 +389,16 @@ func getStatusIconAndStyle(certInfo *certificate.Info, styles Styles, warnDays i
 	case certificate.StatusMismatchedIssuer, certificate.StatusInvalidSignature:
 		return "◆", styles.StatusExpired
 	default:
-		// Otherwise valid, but flag it if it expires within the warning
-		// window so the icon matches the expiry bar and the Validity tab.
-		if certInfo.Certificate != nil && certificate.IsExpiringSoonWithin(certInfo.Certificate, warnDays) {
+		// The status may not have been computed (StatusUnknown/StatusGood),
+		// so fall back to the dates: expired wins, then the warning window,
+		// so the icon matches the expiry bar and the Validity tab.
+		if certInfo.Certificate == nil {
+			return "●", styles.StatusValid
+		}
+		if certificate.IsExpired(certInfo.Certificate) {
+			return "✖", styles.StatusExpired
+		}
+		if certificate.IsExpiringSoonWithin(certInfo.Certificate, warnDays) {
 			return "▲", styles.StatusWarning
 		}
 		return "●", styles.StatusValid

--- a/internal/model/view_test.go
+++ b/internal/model/view_test.go
@@ -1,10 +1,13 @@
 package model
 
 import (
+	"crypto/x509"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/kanywst/y509/internal/config"
+	"github.com/kanywst/y509/pkg/certificate"
 )
 
 func TestChainPositionLabelsLoneSelfSignedAsRoot(t *testing.T) {
@@ -17,6 +20,33 @@ func TestChainPositionLabelsLoneSelfSignedAsRoot(t *testing.T) {
 	}
 	if strings.Contains(out, "Leaf") {
 		t.Errorf("lone self-signed cert should not be labeled Leaf, got:\n%s", out)
+	}
+}
+
+func TestStatusIconReflectsExpiringSoon(t *testing.T) {
+	cfg, _ := config.LoadConfig()
+	styles := NewStyles(&cfg.Theme)
+
+	tests := []struct {
+		name     string
+		notAfter time.Time
+		want     string
+	}{
+		{name: "Expiring within window", notAfter: time.Now().Add(5 * 24 * time.Hour), want: "▲"},
+		{name: "Well in the future", notAfter: time.Now().Add(365 * 24 * time.Hour), want: "●"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			info := &certificate.Info{
+				Certificate:      &x509.Certificate{NotAfter: tt.notAfter},
+				ValidationStatus: certificate.StatusGood,
+			}
+			icon, _ := getStatusIconAndStyle(info, styles, cfg.ExpiryWarningDays)
+			if icon != tt.want {
+				t.Errorf("icon = %q, want %q", icon, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/model/view_test.go
+++ b/internal/model/view_test.go
@@ -35,6 +35,7 @@ func TestStatusIconReflectsExpiringSoon(t *testing.T) {
 		notAfter time.Time
 		want     string
 	}{
+		{name: "Already expired", notAfter: time.Now().Add(-24 * time.Hour), want: "✖"},
 		{name: "Expiring within window", notAfter: time.Now().Add(5 * 24 * time.Hour), want: "▲"},
 		{name: "Well in the future", notAfter: time.Now().Add(365 * 24 * time.Hour), want: "●"},
 	}

--- a/internal/model/view_test.go
+++ b/internal/model/view_test.go
@@ -27,6 +27,9 @@ func TestStatusIconReflectsExpiringSoon(t *testing.T) {
 	cfg, _ := config.LoadConfig()
 	styles := NewStyles(&cfg.Theme)
 
+	// Fixed window so the test doesn't depend on a local .y509 config.
+	const warnDays = 30
+
 	tests := []struct {
 		name     string
 		notAfter time.Time
@@ -42,7 +45,7 @@ func TestStatusIconReflectsExpiringSoon(t *testing.T) {
 				Certificate:      &x509.Certificate{NotAfter: tt.notAfter},
 				ValidationStatus: certificate.StatusGood,
 			}
-			icon, _ := getStatusIconAndStyle(info, styles, cfg.ExpiryWarningDays)
+			icon, _ := getStatusIconAndStyle(info, styles, warnDays)
 			if icon != tt.want {
 				t.Errorf("icon = %q, want %q", icon, tt.want)
 			}


### PR DESCRIPTION
The list status icon only reflected expired, not-yet-valid, and broken chain links. A certificate expiring within the warning window still showed the green valid dot, even though its expiry bar and the Validity tab badge were already yellow.

The icon now flags the same warning window, so all three indicators agree.