### PR TITLE
Keep the frame when a filter matches nothing

### DIFF
--- a/internal/model/logic_test.go
+++ b/internal/model/logic_test.go
@@ -72,6 +72,9 @@ func TestEmptyFilterKeepsFrame(t *testing.T) {
 	if !strings.Contains(view, "Esc") {
 		t.Error("empty state does not tell the user how to clear the filter")
 	}
+	if !strings.Contains(view, "no-such-certificate-anywhere") {
+		t.Error("empty state does not show the search query that matched nothing")
+	}
 }
 
 func TestSearchLogic(t *testing.T) {

--- a/internal/model/logic_test.go
+++ b/internal/model/logic_test.go
@@ -53,6 +53,27 @@ func TestFilterLogic(t *testing.T) {
 	})
 }
 
+func TestEmptyFilterKeepsFrame(t *testing.T) {
+	cfg := loadTestConfig(t)
+	m := *NewModel(createTestCertificates(3), cfg)
+	m.width = 80
+	m.height = 24
+	m.ready = true
+
+	m = m.searchCertificates("no-such-certificate-anywhere")
+	if len(m.certificates) != 0 {
+		t.Fatalf("expected no matches, got %d", len(m.certificates))
+	}
+
+	view := m.renderNormalView()
+	if !strings.Contains(view, "y509") {
+		t.Error("empty state dropped the header")
+	}
+	if !strings.Contains(view, "Esc") {
+		t.Error("empty state does not tell the user how to clear the filter")
+	}
+}
+
 func TestSearchLogic(t *testing.T) {
 	cfg := loadTestConfig(t)
 	certs := createTestCertificates(3)

--- a/internal/model/view.go
+++ b/internal/model/view.go
@@ -71,11 +71,11 @@ func (m Model) renderEmptyState() string {
 
 	msg := "No certificates found."
 	if m.filterActive {
-		term := "filter"
+		term, matched := "filter", m.filterType
 		if m.searchQuery != "" {
-			term = "search"
+			term, matched = "search", m.searchQuery
 		}
-		msg = fmt.Sprintf("Nothing matches %q\n\nPress Esc to clear the %s", m.filterType, term)
+		msg = fmt.Sprintf("Nothing matches %q\n\nPress Esc to clear the %s", matched, term)
 	}
 
 	body := lipgloss.NewStyle().

--- a/internal/model/view.go
+++ b/internal/model/view.go
@@ -67,7 +67,7 @@ func (m Model) renderNormalView() string {
 func (m Model) renderEmptyState() string {
 	header := m.renderHeader()
 	statusBar := m.renderStatusBar()
-	bodyHeight := m.height - lipgloss.Height(header) - lipgloss.Height(statusBar)
+	bodyHeight := max(0, m.height-lipgloss.Height(header)-lipgloss.Height(statusBar))
 
 	msg := "No certificates found."
 	if m.filterActive {

--- a/internal/model/view.go
+++ b/internal/model/view.go
@@ -71,7 +71,11 @@ func (m Model) renderEmptyState() string {
 
 	msg := "No certificates found."
 	if m.filterActive {
-		msg = fmt.Sprintf("Nothing matches %q\n\nPress Esc to clear the filter", m.filterType)
+		term := "filter"
+		if m.searchQuery != "" {
+			term = "search"
+		}
+		msg = fmt.Sprintf("Nothing matches %q\n\nPress Esc to clear the %s", m.filterType, term)
 	}
 
 	body := lipgloss.NewStyle().

--- a/internal/model/view.go
+++ b/internal/model/view.go
@@ -45,7 +45,7 @@ func (m Model) viewContent() string {
 // renderNormalView renders the main view with header, panes, and status bar
 func (m Model) renderNormalView() string {
 	if len(m.certificates) == 0 {
-		return "No certificates found."
+		return m.renderEmptyState()
 	}
 
 	header := m.renderHeader()
@@ -59,6 +59,28 @@ func (m Model) renderNormalView() string {
 	mainContent := lipgloss.NewStyle().Height(panesHeight).Render(panes)
 
 	return lipgloss.JoinVertical(lipgloss.Left, header, mainContent, statusBar)
+}
+
+// renderEmptyState keeps the header and status bar in place when there are
+// no certificates to show, so a filter that matches nothing doesn't blank
+// the screen and the user can see how to get back.
+func (m Model) renderEmptyState() string {
+	header := m.renderHeader()
+	statusBar := m.renderStatusBar()
+	bodyHeight := m.height - lipgloss.Height(header) - lipgloss.Height(statusBar)
+
+	msg := "No certificates found."
+	if m.filterActive {
+		msg = fmt.Sprintf("Nothing matches %q\n\nPress Esc to clear the filter", m.filterType)
+	}
+
+	body := lipgloss.NewStyle().
+		Width(m.width).
+		Height(bodyHeight).
+		Align(lipgloss.Center, lipgloss.Center).
+		Render(m.Styles.Dimmed.Render(msg))
+
+	return lipgloss.JoinVertical(lipgloss.Left, header, body, statusBar)
 }
 
 // renderHeader renders the application header with breadcrumb


### PR DESCRIPTION
A filter or search that matched no certificates replaced the whole view with a bare `No certificates found.` line, dropping the header and status bar. There was no hint that Esc clears the filter, so it looked like the app had lost its data.

Now an empty result keeps the header and status bar and shows what was searched along with a reminder to press Esc to clear it.