### PR TITLE
Label a self-signed certificate as Root

### DIFF
--- a/internal/model/view.go
+++ b/internal/model/view.go
@@ -344,10 +344,10 @@ func (m Model) renderChainPosition(current *certificate.Info) string {
 		}
 		role := "Intermediate"
 		switch {
+		case cert.Certificate.Issuer.String() == cert.Certificate.Subject.String():
+			role = "Root"
 		case i == 0:
 			role = "Leaf"
-		case i == len(m.allCertificates)-1 && cert.Certificate.Issuer.String() == cert.Certificate.Subject.String():
-			role = "Root"
 		}
 		marker := " "
 		if cert == current {

--- a/internal/model/view_test.go
+++ b/internal/model/view_test.go
@@ -7,6 +7,19 @@ import (
 	"github.com/kanywst/y509/internal/config"
 )
 
+func TestChainPositionLabelsLoneSelfSignedAsRoot(t *testing.T) {
+	cfg, _ := config.LoadConfig()
+	m := NewModel(createTestCertificates(1), cfg)
+
+	out := m.renderChainPosition(m.allCertificates[0])
+	if !strings.Contains(out, "Root") {
+		t.Errorf("lone self-signed cert should be labeled Root, got:\n%s", out)
+	}
+	if strings.Contains(out, "Leaf") {
+		t.Errorf("lone self-signed cert should not be labeled Leaf, got:\n%s", out)
+	}
+}
+
 func TestRenderHeader(t *testing.T) {
 	cfg, _ := config.LoadConfig()
 	m := NewModel(createTestCertificates(1), cfg)


### PR DESCRIPTION
The chain position table checked `i == 0` before the self-signed test, so a single self-signed certificate (or any chain whose leaf is its own issuer) showed up as Leaf instead of Root.

Check the self-signed case first.