### PR TITLE
Close the help overlay on q instead of quitting

### DIFF
--- a/internal/model/update.go
+++ b/internal/model/update.go
@@ -46,18 +46,18 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.viewMode = ViewNormal
 			return m, nil
 		}
-		// Global quit (except in Popup mode where q might be part of input)
-		if m.viewMode != ViewPopup {
-			if key.Matches(msg, m.keys.Quit) {
-				return m, tea.Quit
-			}
-		} else if msg.String() == "ctrl+c" {
-			// In Popup, only Ctrl+C quits app. Esc closes popup.
+		// Ctrl+C always quits. In help and popup modes, the other keys
+		// close the overlay rather than the app, so q only quits from
+		// the normal view.
+		if msg.String() == "ctrl+c" {
 			return m, tea.Quit
 		}
 
 		switch m.viewMode {
 		case ViewNormal:
+			if key.Matches(msg, m.keys.Quit) {
+				return m, tea.Quit
+			}
 			return m.updateNormalMode(msg)
 		case ViewHelp:
 			return m.updateHelpMode(msg)

--- a/internal/model/update.go
+++ b/internal/model/update.go
@@ -42,15 +42,16 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case tea.KeyPressMsg:
-		if m.viewMode == ViewSplash {
-			m.viewMode = ViewNormal
-			return m, nil
-		}
-		// Ctrl+C always quits. In help and popup modes, the other keys
-		// close the overlay rather than the app, so q only quits from
+		// Ctrl+C always quits, before any mode-specific handling (including
+		// the splash dismissal below). In help and popup modes the other
+		// keys close the overlay rather than the app, so q only quits from
 		// the normal view.
 		if msg.String() == "ctrl+c" {
 			return m, tea.Quit
+		}
+		if m.viewMode == ViewSplash {
+			m.viewMode = ViewNormal
+			return m, nil
 		}
 
 		switch m.viewMode {

--- a/internal/model/update_test.go
+++ b/internal/model/update_test.go
@@ -109,3 +109,25 @@ func TestHelpModeQClosesWithoutQuitting(t *testing.T) {
 		t.Error("q in help mode should not issue a command (no quit)")
 	}
 }
+
+func TestCtrlCQuitsFromSplash(t *testing.T) {
+	cfg := loadTestConfig(t)
+	m := *NewModel([]*certificate.Info{createDummyCert(1)}, cfg)
+	// Still on the splash screen.
+	if m.viewMode != ViewSplash {
+		t.Fatalf("expected initial ViewSplash, got %v", m.viewMode)
+	}
+
+	ctrlC := tea.KeyPressMsg(tea.Key{Code: 'c', Mod: tea.ModCtrl})
+	if ctrlC.String() != "ctrl+c" {
+		t.Fatalf("test setup wrong, key string = %q", ctrlC.String())
+	}
+
+	_, cmd := m.Update(ctrlC)
+	if cmd == nil {
+		t.Fatal("expected a quit command from ctrl+c on splash")
+	}
+	if _, ok := cmd().(tea.QuitMsg); !ok {
+		t.Error("ctrl+c on splash did not produce tea.QuitMsg")
+	}
+}

--- a/internal/model/update_test.go
+++ b/internal/model/update_test.go
@@ -92,3 +92,20 @@ func TestNavigationKeys(t *testing.T) {
 		}
 	})
 }
+
+func TestHelpModeQClosesWithoutQuitting(t *testing.T) {
+	cfg := loadTestConfig(t)
+	m := *NewModel([]*certificate.Info{createDummyCert(1)}, cfg)
+	m.ready = true
+	m.viewMode = ViewHelp
+
+	newModel, cmd := m.Update(keyPress('q'))
+	m = newModel.(Model)
+
+	if m.viewMode != ViewNormal {
+		t.Errorf("expected help to close to ViewNormal, got %v", m.viewMode)
+	}
+	if cmd != nil {
+		t.Error("q in help mode should not issue a command (no quit)")
+	}
+}


### PR DESCRIPTION
The global quit check ran before the per-mode key handlers, so pressing q while the help overlay was open quit the whole app instead of closing the overlay.

Now only Ctrl+C quits globally. q quits only from the normal view, and in the help overlay any key (including q) closes it.