### PR TITLE
Truncate names by rune, not byte

### DIFF
--- a/internal/model/utils.go
+++ b/internal/model/utils.go
@@ -8,16 +8,19 @@ func getMinimumSize() (int, int) {
 	return 20, 6 // minimum 20 chars wide, 6 lines high
 }
 
-// truncateText truncates text to fit within the specified width with ellipsis
+// truncateText truncates text to the given number of characters with an
+// ellipsis. It counts and slices runes, not bytes, so multibyte names
+// (CJK, IDNs) aren't cut mid-character.
 func truncateText(text string, width int) string {
 	if width <= 0 {
 		return ""
 	}
-	if len(text) <= width {
+	r := []rune(text)
+	if len(r) <= width {
 		return text
 	}
 	if width <= 3 {
 		return strings.Repeat(".", width)
 	}
-	return text[:width-3] + "..."
+	return string(r[:width-3]) + "..."
 }

--- a/internal/model/utils_test.go
+++ b/internal/model/utils_test.go
@@ -15,6 +15,8 @@ func TestTruncateText(t *testing.T) {
 		{name: "Fits", text: "short", width: 10, want: "short"},
 		{name: "ASCII truncated", text: "abcdefghij", width: 7, want: "abcd..."},
 		{name: "Zero width", text: "abc", width: 0, want: ""},
+		{name: "Negative width", text: "abc", width: -5, want: ""},
+		{name: "Width equals three", text: "abcdef", width: 3, want: "..."},
 		{name: "Tiny width", text: "abcdef", width: 2, want: ".."},
 		{name: "Multibyte fits", text: "日本語", width: 5, want: "日本語"},
 		{name: "Multibyte truncated", text: "日本語テスト", width: 5, want: "日本..."},

--- a/internal/model/utils_test.go
+++ b/internal/model/utils_test.go
@@ -1,0 +1,34 @@
+package model
+
+import (
+	"testing"
+	"unicode/utf8"
+)
+
+func TestTruncateText(t *testing.T) {
+	tests := []struct {
+		name  string
+		text  string
+		width int
+		want  string
+	}{
+		{name: "Fits", text: "short", width: 10, want: "short"},
+		{name: "ASCII truncated", text: "abcdefghij", width: 7, want: "abcd..."},
+		{name: "Zero width", text: "abc", width: 0, want: ""},
+		{name: "Tiny width", text: "abcdef", width: 2, want: ".."},
+		{name: "Multibyte fits", text: "日本語", width: 5, want: "日本語"},
+		{name: "Multibyte truncated", text: "日本語テスト", width: 5, want: "日本..."},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := truncateText(tt.text, tt.width)
+			if got != tt.want {
+				t.Errorf("truncateText(%q, %d) = %q, want %q", tt.text, tt.width, got, tt.want)
+			}
+			if !utf8.ValidString(got) {
+				t.Errorf("truncateText(%q, %d) produced invalid UTF-8: %q", tt.text, tt.width, got)
+			}
+		})
+	}
+}

--- a/pkg/certificate/certificate.go
+++ b/pkg/certificate/certificate.go
@@ -754,9 +754,10 @@ func generateCertificateLabel(cert *x509.Certificate, index int) string {
 		cn = "Unknown"
 	}
 
-	// Truncate long common names
-	if len(cn) > 30 {
-		cn = cn[:27] + "..."
+	// Truncate long common names by rune so multibyte names aren't cut
+	// mid-character.
+	if r := []rune(cn); len(r) > 30 {
+		cn = string(r[:27]) + "..."
 	}
 
 	return fmt.Sprintf("%d. %s", index+1, cn)


### PR DESCRIPTION
`truncateText` and the certificate label truncation sliced raw bytes. A multibyte common name (CJK, an internationalized domain) could be cut in the middle of a rune and render as garbage.

Both now count and slice runes. Added a test covering ASCII and multibyte truncation that also checks the result is valid UTF-8.