### PR TITLE
De-duplicate splash ASCII art

### DIFF
--- a/internal/model/splash.go
+++ b/internal/model/splash.go
@@ -16,6 +16,18 @@ const (
 	MediumArtHeightThreshold = 14
 )
 
+const compactSplashArt = `
+ ██   ██ ███████  ██████   █████
+  ████   ██       █████   ██   ██
+   ██    ███████ ██    ██  █████  `
+
+const fullSplashArt = `
+██    ██ ███████  ██████   █████
+ ██  ██  ██      ██    ██ ██   ██
+  ████   ███████ ██    ██  █████
+   ██         ██ ██    ██      ██
+   ██    ███████  ██████   █████  `
+
 // renderSplashScreen renders the y509 ASCII art splash screen with adaptive sizing
 func (m Model) renderSplashScreen() string {
 	ver := version.GetShortVersion()
@@ -23,27 +35,15 @@ func (m Model) renderSplashScreen() string {
 	var asciiArt string
 	var subtitle string
 
-	if m.width < CompactArtWidthThreshold || m.height < CompactArtHeightThreshold {
-		asciiArt = `
- ██   ██ ███████  ██████   █████
-  ████   ██       █████   ██   ██
-   ██    ███████ ██    ██  █████  `
+	switch {
+	case m.width < CompactArtWidthThreshold || m.height < CompactArtHeightThreshold:
+		asciiArt = compactSplashArt
 		subtitle = fmt.Sprintf("Certificate Chain TUI Viewer  %s", ver)
-	} else if m.width < MediumArtWidthThreshold || m.height < MediumArtHeightThreshold {
-		asciiArt = `
-██    ██ ███████  ██████   █████
- ██  ██  ██      ██    ██ ██   ██
-  ████   ███████ ██    ██  █████
-   ██         ██ ██    ██      ██
-   ██    ███████  ██████   █████  `
+	case m.width < MediumArtWidthThreshold || m.height < MediumArtHeightThreshold:
+		asciiArt = fullSplashArt
 		subtitle = fmt.Sprintf("Certificate Chain TUI Viewer  %s", ver)
-	} else {
-		asciiArt = `
-██    ██ ███████  ██████   █████
- ██  ██  ██      ██    ██ ██   ██
-  ████   ███████ ██    ██  █████
-   ██         ██ ██    ██      ██
-   ██    ███████  ██████   █████  `
+	default:
+		asciiArt = fullSplashArt
 		subtitle = fmt.Sprintf("🔐  Certificate Chain TUI Viewer\n%s", ver)
 	}
 


### PR DESCRIPTION
The medium and large splash branches used byte-identical ASCII art and differed only in the subtitle. Pulled the two art variants out as constants and kept the size branching for the subtitle.