### PR TITLE
Collapse the tab strip on narrow terminals

### DIFF
--- a/internal/model/view.go
+++ b/internal/model/view.go
@@ -250,7 +250,9 @@ func (m Model) renderTabs(width int) string {
 	full := lipgloss.JoinHorizontal(lipgloss.Top, renderedTabs...)
 
 	budget := width - 2 // pane side borders
-	if budget <= 0 || lipgloss.Width(full) <= budget {
+	// Only keep the full strip when it actually fits; at ultra-narrow widths
+	// (budget <= 0) fall through to the compact form.
+	if budget > 0 && lipgloss.Width(full) <= budget {
 		return full
 	}
 

--- a/internal/model/view.go
+++ b/internal/model/view.go
@@ -229,21 +229,38 @@ func (m Model) renderRightPane(width, height int) string {
 	return paneStyle.Width(width).Height(height).Render(paneContent)
 }
 
-// renderTabs renders the UI for switching between detail tabs with underline indicator
-func (m Model) renderTabs(_ int) string {
+// renderTabs renders the detail-tab switcher. When the full strip doesn't
+// fit the pane width it collapses to a compact "‹ Active ›  i/n" form so the
+// tabs never wrap and push the pane border out of alignment. Both forms are
+// two rows tall (label + underline) to keep the pane geometry constant.
+func (m Model) renderTabs(width int) string {
 	var renderedTabs []string
 	for i, t := range m.tabs {
+		cellWidth := lipgloss.Width(t) + 4
 		if i == m.activeTab {
 			label := m.Styles.TabActive.Render(t)
-			underline := m.Styles.Title.Render(strings.Repeat("━", lipgloss.Width(t)+4))
+			underline := m.Styles.Title.Render(strings.Repeat("━", cellWidth))
 			renderedTabs = append(renderedTabs, lipgloss.JoinVertical(lipgloss.Center, label, underline))
 		} else {
 			label := m.Styles.Tab.Render(t)
-			spacer := lipgloss.NewStyle().Render(strings.Repeat(" ", lipgloss.Width(t)+4))
+			spacer := strings.Repeat(" ", cellWidth)
 			renderedTabs = append(renderedTabs, lipgloss.JoinVertical(lipgloss.Center, label, spacer))
 		}
 	}
-	return lipgloss.JoinHorizontal(lipgloss.Top, renderedTabs...)
+	full := lipgloss.JoinHorizontal(lipgloss.Top, renderedTabs...)
+
+	budget := width - 2 // pane side borders
+	if budget <= 0 || lipgloss.Width(full) <= budget {
+		return full
+	}
+
+	// Compact fallback for narrow panes.
+	active := m.tabs[m.activeTab]
+	label := m.Styles.Dimmed.Render("‹ ") +
+		m.Styles.Title.Bold(true).Render(active) +
+		m.Styles.Dimmed.Render(fmt.Sprintf(" ›  %d/%d", m.activeTab+1, len(m.tabs)))
+	underline := m.Styles.Title.Render(strings.Repeat("━", lipgloss.Width(active)+2))
+	return lipgloss.JoinVertical(lipgloss.Center, label, underline)
 }
 
 // renderTabContent renders the content for the currently active tab.

--- a/internal/model/view.go
+++ b/internal/model/view.go
@@ -256,13 +256,14 @@ func (m Model) renderTabs(width int) string {
 		return full
 	}
 
-	// Compact fallback for narrow panes.
+	// Compact fallback for narrow panes. Left-align and offset the rule by
+	// the "‹ " prefix so it sits directly under the active tab name.
 	active := m.tabs[m.activeTab]
 	label := m.Styles.Dimmed.Render("‹ ") +
 		m.Styles.Title.Bold(true).Render(active) +
 		m.Styles.Dimmed.Render(fmt.Sprintf(" ›  %d/%d", m.activeTab+1, len(m.tabs)))
-	underline := m.Styles.Title.Render(strings.Repeat("━", lipgloss.Width(active)+2))
-	return lipgloss.JoinVertical(lipgloss.Center, label, underline)
+	underline := "  " + m.Styles.Title.Render(strings.Repeat("━", lipgloss.Width(active)))
+	return lipgloss.JoinVertical(lipgloss.Left, label, underline)
 }
 
 // renderTabContent renders the content for the currently active tab.

--- a/internal/model/view.go
+++ b/internal/model/view.go
@@ -234,10 +234,18 @@ func (m Model) renderRightPane(width, height int) string {
 // tabs never wrap and push the pane border out of alignment. Both forms are
 // two rows tall (label + underline) to keep the pane geometry constant.
 func (m Model) renderTabs(width int) string {
+	if len(m.tabs) == 0 {
+		return ""
+	}
+	activeIdx := m.activeTab
+	if activeIdx < 0 || activeIdx >= len(m.tabs) {
+		activeIdx = 0
+	}
+
 	var renderedTabs []string
 	for i, t := range m.tabs {
 		cellWidth := lipgloss.Width(t) + 4
-		if i == m.activeTab {
+		if i == activeIdx {
 			label := m.Styles.TabActive.Render(t)
 			underline := m.Styles.Title.Render(strings.Repeat("━", cellWidth))
 			renderedTabs = append(renderedTabs, lipgloss.JoinVertical(lipgloss.Center, label, underline))
@@ -258,10 +266,10 @@ func (m Model) renderTabs(width int) string {
 
 	// Compact fallback for narrow panes. Left-align and offset the rule by
 	// the "‹ " prefix so it sits directly under the active tab name.
-	active := m.tabs[m.activeTab]
+	active := m.tabs[activeIdx]
 	label := m.Styles.Dimmed.Render("‹ ") +
 		m.Styles.Title.Bold(true).Render(active) +
-		m.Styles.Dimmed.Render(fmt.Sprintf(" ›  %d/%d", m.activeTab+1, len(m.tabs)))
+		m.Styles.Dimmed.Render(fmt.Sprintf(" ›  %d/%d", activeIdx+1, len(m.tabs)))
 	underline := "  " + m.Styles.Title.Render(strings.Repeat("━", lipgloss.Width(active)))
 	return lipgloss.JoinVertical(lipgloss.Left, label, underline)
 }


### PR DESCRIPTION
On a narrow terminal the full `Subject  Issuer  Validity  SANs  Misc` strip wrapped onto a second line. That made the right pane one row taller than the left and their bottom borders no longer lined up.

When the full strip is wider than the pane, it now collapses to a compact `‹ Active ›  i/n` indicator. Both forms are two rows tall, so the pane geometry stays constant.

Before (70 cols):
```
│  Subject    Issuer    Validity    SANs │
│Misc                                    │
```
After:
```
│‹ Validity ›  3/5                       │
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tab rendering to be responsive to available pane width: the full single-row horizontal tab strip is used when it fits.
  * When space is constrained, tabs switch to a compact two-row layout with a clear active-tab label, “‹ … ›” navigation cues, and a position indicator to avoid wrapping and underline/border misalignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->