### PR TITLE
Show a scroll indicator when detail content overflows

### DIFF
--- a/internal/model/constants.go
+++ b/internal/model/constants.go
@@ -55,4 +55,8 @@ const (
 	// The left pane uses BorderRight(false), so only one border column
 	// occupies horizontal space.
 	PaneSideBorderWidth = 1
+
+	// PaneBorderWidth accounts for both side border columns on a pane that
+	// draws a full border (the right pane), used when sizing inner width.
+	PaneBorderWidth = 2
 )

--- a/internal/model/update.go
+++ b/internal/model/update.go
@@ -190,7 +190,7 @@ func (m Model) resizeComponents() Model {
 	const verticalPadding = 1
 	const tabStripHeight = 2 // label row + underline row
 	const scrollFooterHeight = 1
-	vpWidth := rightPaneWidth - 2*horizontalPadding - PaneBorderHeight
+	vpWidth := rightPaneWidth - 2*horizontalPadding - PaneBorderWidth
 	vpHeight := paneHeight - PaneBorderHeight - tabStripHeight - 2*verticalPadding - scrollFooterHeight
 	if vpWidth < 1 {
 		vpWidth = 1

--- a/internal/model/update.go
+++ b/internal/model/update.go
@@ -189,8 +189,9 @@ func (m Model) resizeComponents() Model {
 	const horizontalPadding = 2
 	const verticalPadding = 1
 	const tabStripHeight = 2 // label row + underline row
+	const scrollFooterHeight = 1
 	vpWidth := rightPaneWidth - 2*horizontalPadding - PaneBorderHeight
-	vpHeight := paneHeight - PaneBorderHeight - tabStripHeight - 2*verticalPadding
+	vpHeight := paneHeight - PaneBorderHeight - tabStripHeight - 2*verticalPadding - scrollFooterHeight
 	if vpWidth < 1 {
 		vpWidth = 1
 	}

--- a/internal/model/view.go
+++ b/internal/model/view.go
@@ -239,9 +239,8 @@ func (m Model) renderScrollFooter(width int) string {
 	if width < 1 {
 		width = 1
 	}
-	blank := lipgloss.NewStyle().Width(width).Render("")
 	if m.viewport.TotalLineCount() <= m.viewport.Height() {
-		return blank
+		return strings.Repeat(" ", width)
 	}
 
 	up, down := " ", " "

--- a/internal/model/view.go
+++ b/internal/model/view.go
@@ -221,7 +221,7 @@ func (m Model) renderRightPane(width, height int) string {
 		Render(m.viewport.View())
 	// Inner width is the pane width minus its two border columns; the footer
 	// then loses the same horizontal padding as the content above it.
-	footer := m.renderScrollFooter(width - PaneBorderHeight - 2*horizontalPadding)
+	footer := m.renderScrollFooter(width - PaneBorderWidth - 2*horizontalPadding)
 	footer = lipgloss.NewStyle().Padding(0, horizontalPadding).Render(footer)
 	paneContent := lipgloss.JoinVertical(lipgloss.Left, tabs, paddedContent, footer)
 

--- a/internal/model/view.go
+++ b/internal/model/view.go
@@ -219,7 +219,9 @@ func (m Model) renderRightPane(width, height int) string {
 	paddedContent := lipgloss.NewStyle().
 		Padding(verticalPadding, horizontalPadding).
 		Render(m.viewport.View())
-	footer := m.renderScrollFooter(width - 2*horizontalPadding)
+	// Inner width is the pane width minus its two border columns; the footer
+	// then loses the same horizontal padding as the content above it.
+	footer := m.renderScrollFooter(width - PaneBorderHeight - 2*horizontalPadding)
 	footer = lipgloss.NewStyle().Padding(0, horizontalPadding).Render(footer)
 	paneContent := lipgloss.JoinVertical(lipgloss.Left, tabs, paddedContent, footer)
 

--- a/internal/model/view.go
+++ b/internal/model/view.go
@@ -219,13 +219,41 @@ func (m Model) renderRightPane(width, height int) string {
 	paddedContent := lipgloss.NewStyle().
 		Padding(verticalPadding, horizontalPadding).
 		Render(m.viewport.View())
-	paneContent := lipgloss.JoinVertical(lipgloss.Left, tabs, paddedContent)
+	footer := m.renderScrollFooter(width - 2*horizontalPadding)
+	footer = lipgloss.NewStyle().Padding(0, horizontalPadding).Render(footer)
+	paneContent := lipgloss.JoinVertical(lipgloss.Left, tabs, paddedContent, footer)
 
 	paneStyle := m.Styles.Pane
 	if m.focus == FocusRight {
 		paneStyle = m.Styles.PaneFocus
 	}
 	return paneStyle.Width(width).Height(height).Render(paneContent)
+}
+
+// renderScrollFooter renders a one-row scroll indicator for the detail
+// viewport. It always returns a single row (blank when the content fits)
+// so the pane height stays constant; resizeComponents reserves the row.
+func (m Model) renderScrollFooter(width int) string {
+	if width < 1 {
+		width = 1
+	}
+	blank := lipgloss.NewStyle().Width(width).Render("")
+	if m.viewport.TotalLineCount() <= m.viewport.Height() {
+		return blank
+	}
+
+	up, down := " ", " "
+	if !m.viewport.AtTop() {
+		up = "▲"
+	}
+	if !m.viewport.AtBottom() {
+		down = "▼"
+	}
+	hint := fmt.Sprintf("%s %s  %3.0f%%", up, down, m.viewport.ScrollPercent()*100)
+	return lipgloss.NewStyle().
+		Width(width).
+		Align(lipgloss.Right).
+		Render(m.Styles.Dimmed.Render(hint))
 }
 
 // renderTabs renders the detail-tab switcher. When the full strip doesn't

--- a/internal/model/view_test.go
+++ b/internal/model/view_test.go
@@ -138,3 +138,23 @@ func TestMinimumSizeWarning(t *testing.T) {
 		t.Errorf("Minimum size warning not displayed or correctly wrapped")
 	}
 }
+
+func TestScrollFooterAppearsOnOverflow(t *testing.T) {
+	cfg, _ := config.LoadConfig()
+	m := NewModel(createTestCertificates(1), cfg)
+	m.viewport.SetWidth(50)
+	m.viewport.SetHeight(5)
+
+	// Short content fits: no scroll arrows.
+	m.viewport.SetContent("one line")
+	if strings.ContainsAny(m.renderRightPane(54, 20), "▲▼") {
+		t.Error("scroll footer shown when content fits")
+	}
+
+	// Tall content overflows: a down arrow should appear at the top.
+	m.viewport.SetContent(strings.Repeat("line\n", 30))
+	m.viewport.GotoTop()
+	if !strings.Contains(m.renderRightPane(54, 20), "▼") {
+		t.Error("scroll footer missing when content overflows")
+	}
+}


### PR DESCRIPTION
The right detail pane silently clipped any content taller than the viewport. On the Misc tab, for example, the bottom border of the chain table just disappeared with no sign there was more below.

Reserve a one-row footer at the bottom of the pane that shows up/down arrows and a scroll percentage whenever the content doesn't fit. The row is always present (blank when everything fits) so the pane height stays constant.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a scroll indicator footer beneath the details pane. It appears only when the content overflows and shows up/down arrows (▲▼) plus the current scroll percentage, updating based on whether you’re at the top or bottom.
* **Bug Fixes**
  * Improved right-pane sizing so the footer/layout aligns correctly with header/tab padding and borders.
* **Tests**
  * Added coverage to verify the arrow indicators render (or hide) correctly for both fitting and overflowing content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->