### PR TITLE
Keep detail values aligned and readable

### DIFF
--- a/internal/model/view.go
+++ b/internal/model/view.go
@@ -350,21 +350,24 @@ func (m Model) renderTabContent(width int) string {
 	var b strings.Builder
 
 	// Keep the key column from crowding out the value on narrow panes: shrink
-	// it so key + value never exceed the available width.
+	// it so key + value never exceed the available width (down to a zero-width
+	// key on extremely narrow panes).
 	keyWidth := 16
-	if width-keyWidth < 8 {
-		keyWidth = width - 8
+	if keyWidth > width-8 {
+		keyWidth = width - 8 // prefer at least 8 cells for the value
 	}
-	if keyWidth < 4 {
-		keyWidth = 4
+	if keyWidth < 0 {
+		keyWidth = 0
 	}
 	valueWidth := width - keyWidth
 	if valueWidth < 1 {
 		valueWidth = 1
+		keyWidth = max(0, width-1)
 	}
 
 	// kv renders an aligned key/value row. Long values wrap inside the value
-	// column instead of spilling back to the left margin.
+	// column instead of spilling back to the left margin. An empty key gives
+	// a blank column so continuation/section lines still align with values.
 	kv := func(key, value string) {
 		if value == "" {
 			return
@@ -385,11 +388,7 @@ func (m Model) renderTabContent(width int) string {
 			if k, v, ok := strings.Cut(line, ": "); ok {
 				kv(k, v)
 			} else {
-				// No key: blank key cell so it still aligns under the value
-				// column and wraps there instead of at the left margin.
-				keyCell := m.Styles.DetailKey.Width(keyWidth).Render("")
-				valueCell := m.Styles.DetailValue.Width(valueWidth).Render(line)
-				b.WriteString(lipgloss.JoinHorizontal(lipgloss.Top, keyCell, valueCell) + "\n")
+				kv("", line)
 			}
 		}
 	}

--- a/internal/model/view.go
+++ b/internal/model/view.go
@@ -343,7 +343,7 @@ func groupHex(hexStr string) string {
 // by the caller's viewport.
 func (m Model) renderTabContent(width int) string {
 	idx := m.list.Index()
-	if idx < 0 || idx >= len(m.certificates) || m.certificates[idx].Certificate == nil {
+	if idx < 0 || idx >= len(m.certificates) || m.certificates[idx] == nil || m.certificates[idx].Certificate == nil {
 		return ""
 	}
 	cert := m.certificates[idx]

--- a/internal/model/view.go
+++ b/internal/model/view.go
@@ -317,6 +317,24 @@ func (m Model) renderTabs(width int) string {
 	return lipgloss.JoinVertical(lipgloss.Left, label, underline)
 }
 
+// groupHex inserts a colon between every byte (two hex chars) so a long
+// fingerprint reads like the familiar AA:BB:CC form and can wrap on the
+// separators instead of as one unbroken string.
+func groupHex(hexStr string) string {
+	var b strings.Builder
+	for i := 0; i < len(hexStr); i += 2 {
+		end := i + 2
+		if end > len(hexStr) {
+			end = len(hexStr)
+		}
+		if i > 0 {
+			b.WriteByte(':')
+		}
+		b.WriteString(hexStr[i:end])
+	}
+	return b.String()
+}
+
 // renderTabContent renders the content for the currently active tab.
 // Width is used to size the inner column; vertical truncation is handled
 // by the caller's viewport.
@@ -324,17 +342,37 @@ func (m Model) renderTabContent(width int) string {
 	cert := m.certificates[m.list.Index()]
 	var b strings.Builder
 
+	const keyWidth = 16
+	valueWidth := width - keyWidth
+	if valueWidth < 8 {
+		valueWidth = 8
+	}
+
+	// kv renders an aligned key/value row. Long values wrap inside the value
+	// column instead of spilling back to the left margin.
 	kv := func(key, value string) {
 		if value == "" {
 			return
 		}
-		keyStyle := m.Styles.DetailKey.Width(16)
-		valueStyle := m.Styles.DetailValue
-		row := lipgloss.JoinHorizontal(lipgloss.Left,
-			keyStyle.Render(key),
-			valueStyle.Render(value),
-		)
+		keyCell := m.Styles.DetailKey.Width(keyWidth).Render(key)
+		valueCell := m.Styles.DetailValue.Width(valueWidth).Render(value)
+		row := lipgloss.JoinHorizontal(lipgloss.Top, keyCell, valueCell)
 		b.WriteString(row + "\n")
+	}
+
+	// kvLines feeds "Key: Value" lines (e.g. from FormatPublicKey) through kv
+	// so they share the same alignment as the rest of the tab.
+	kvLines := func(text string) {
+		for _, line := range strings.Split(strings.TrimRight(text, "\n"), "\n") {
+			if line == "" {
+				continue
+			}
+			if k, v, ok := strings.Cut(line, ": "); ok {
+				kv(k, v)
+			} else {
+				b.WriteString(m.Styles.DetailValue.Render(line) + "\n")
+			}
+		}
 	}
 
 	switch m.tabs[m.activeTab] {
@@ -354,7 +392,7 @@ func (m Model) renderTabContent(width int) string {
 		notAfter := cert.Certificate.NotAfter.Format("2006-01-02 15:04:05 MST")
 		kv("Not Before", notBefore)
 		kv("Not After", notAfter)
-		kv("Period", fmt.Sprintf("%d days", certificate.ValidityPeriodDays(cert.Certificate)))
+		kv("Lifetime", fmt.Sprintf("%d days total", certificate.ValidityPeriodDays(cert.Certificate)))
 
 		// Validity status badge
 		b.WriteString("\n")
@@ -364,9 +402,9 @@ func (m Model) renderTabContent(width int) string {
 		} else {
 			days := int(d.Hours() / 24)
 			if days <= m.Config.ExpiryWarningDays {
-				b.WriteString(m.Styles.BadgeWarning.Render(fmt.Sprintf("  ▲ Expires in %d days", days)) + "\n")
+				b.WriteString(m.Styles.BadgeWarning.Render(fmt.Sprintf("  ▲ %d days left", days)) + "\n")
 			} else {
-				b.WriteString(m.Styles.BadgeValid.Render(fmt.Sprintf("  ● Valid for %d days", days)) + "\n")
+				b.WriteString(m.Styles.BadgeValid.Render(fmt.Sprintf("  ● Valid · %d days left", days)) + "\n")
 			}
 		}
 
@@ -418,11 +456,11 @@ func (m Model) renderTabContent(width int) string {
 		}
 	case "Misc":
 		kv("Serial", cert.Certificate.SerialNumber.String())
-		kv("SHA256", certificate.FormatFingerprint(cert.Certificate))
+		kv("SHA256", groupHex(certificate.FormatFingerprint(cert.Certificate)))
 		kv("Sig Algo", cert.Certificate.SignatureAlgorithm.String())
 		b.WriteString("\n")
 		b.WriteString(m.Styles.SectionTitle.Render("Public Key") + "\n")
-		b.WriteString(certificate.FormatPublicKey(cert.Certificate) + "\n")
+		kvLines(certificate.FormatPublicKey(cert.Certificate))
 
 		// Chain position visualization
 		b.WriteString("\n")

--- a/internal/model/view.go
+++ b/internal/model/view.go
@@ -349,10 +349,18 @@ func (m Model) renderTabContent(width int) string {
 	cert := m.certificates[idx]
 	var b strings.Builder
 
-	const keyWidth = 16
+	// Keep the key column from crowding out the value on narrow panes: shrink
+	// it so key + value never exceed the available width.
+	keyWidth := 16
+	if width-keyWidth < 8 {
+		keyWidth = width - 8
+	}
+	if keyWidth < 4 {
+		keyWidth = 4
+	}
 	valueWidth := width - keyWidth
-	if valueWidth < 8 {
-		valueWidth = 8
+	if valueWidth < 1 {
+		valueWidth = 1
 	}
 
 	// kv renders an aligned key/value row. Long values wrap inside the value
@@ -377,8 +385,11 @@ func (m Model) renderTabContent(width int) string {
 			if k, v, ok := strings.Cut(line, ": "); ok {
 				kv(k, v)
 			} else {
-				// No key: render full width so it still wraps in the column.
-				b.WriteString(m.Styles.DetailValue.Width(width).Render(line) + "\n")
+				// No key: blank key cell so it still aligns under the value
+				// column and wraps there instead of at the left margin.
+				keyCell := m.Styles.DetailKey.Width(keyWidth).Render("")
+				valueCell := m.Styles.DetailValue.Width(valueWidth).Render(line)
+				b.WriteString(lipgloss.JoinHorizontal(lipgloss.Top, keyCell, valueCell) + "\n")
 			}
 		}
 	}

--- a/internal/model/view.go
+++ b/internal/model/view.go
@@ -322,6 +322,9 @@ func (m Model) renderTabs(width int) string {
 // separators instead of as one unbroken string.
 func groupHex(hexStr string) string {
 	var b strings.Builder
+	if n := len(hexStr); n > 0 {
+		b.Grow(n + (n-1)/2) // bytes plus one colon per pair after the first
+	}
 	for i := 0; i < len(hexStr); i += 2 {
 		end := i + 2
 		if end > len(hexStr) {
@@ -339,7 +342,11 @@ func groupHex(hexStr string) string {
 // Width is used to size the inner column; vertical truncation is handled
 // by the caller's viewport.
 func (m Model) renderTabContent(width int) string {
-	cert := m.certificates[m.list.Index()]
+	idx := m.list.Index()
+	if idx < 0 || idx >= len(m.certificates) || m.certificates[idx].Certificate == nil {
+		return ""
+	}
+	cert := m.certificates[idx]
 	var b strings.Builder
 
 	const keyWidth = 16
@@ -370,7 +377,8 @@ func (m Model) renderTabContent(width int) string {
 			if k, v, ok := strings.Cut(line, ": "); ok {
 				kv(k, v)
 			} else {
-				b.WriteString(m.Styles.DetailValue.Render(line) + "\n")
+				// No key: render full width so it still wraps in the column.
+				b.WriteString(m.Styles.DetailValue.Width(width).Render(line) + "\n")
 			}
 		}
 	}

--- a/internal/model/view_test.go
+++ b/internal/model/view_test.go
@@ -158,3 +158,18 @@ func TestScrollFooterAppearsOnOverflow(t *testing.T) {
 		t.Error("scroll footer missing when content overflows")
 	}
 }
+
+func TestGroupHex(t *testing.T) {
+	cases := map[string]string{
+		"":         "",
+		"ab":       "ab",
+		"abcd":     "ab:cd",
+		"abcde":    "ab:cd:e",
+		"0011aabb": "00:11:aa:bb",
+	}
+	for in, want := range cases {
+		if got := groupHex(in); got != want {
+			t.Errorf("groupHex(%q) = %q, want %q", in, got, want)
+		}
+	}
+}


### PR DESCRIPTION
Long values in the detail tabs wrapped back to the left margin, so the label looked empty and the wrapped text ran together. The worst case was the SHA-256 fingerprint on the Misc tab:

```
SHA256
6f261bcd1ba6d10e49af8bd39fa71cdd8a9b67989d65e086cf64fb
561025c4ac
```

Changes:
- Wrap values inside the value column so continuation lines stay aligned under the value, not at the left margin.
- Group the fingerprint into `AA:BB:CC` bytes.
- Render the public key block through the same aligned key/value helper instead of raw text.
- Relabel validity as `Lifetime  366 days total` and `● Valid · 360 days left` so the total lifetime and the remaining time aren't easy to confuse.

After:
```
SHA256          6f:26:1b:cd:1b:a6:d1:0e:49:af:8b:d3:9f
                :a7:1c:dd:8a:9b:67:98:9d:65:e0:86:cf:6
                4:fb:56:10:25:c4:ac
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved certificate details display with better formatting and alignment for validity information, SHA256 fingerprint, and public key details.
  * Updated validity status badge text for clearer certificate expiration messaging.

* **Tests**
  * Added unit test coverage for formatting helper.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->