### PR TITLE
Make both expiry bars fill in the same direction

### DIFF
--- a/internal/model/view.go
+++ b/internal/model/view.go
@@ -2,7 +2,6 @@ package model
 
 import (
 	"fmt"
-	"math"
 	"strings"
 	"time"
 
@@ -306,10 +305,15 @@ func (m Model) renderTabContent(width int) string {
 
 		// Life-remaining bar. Fills with the fraction of the lifetime still
 		// left, matching the list's expiry bar (full = healthy) so the two
-		// bars never read in opposite directions.
-		totalLife := cert.Certificate.NotAfter.Sub(cert.Certificate.NotBefore).Hours() / 24
-		remaining := time.Until(cert.Certificate.NotAfter).Hours() / 24
-		ratio := remaining / math.Max(totalLife, 1)
+		// bars never read in opposite directions. Compute in Unix seconds to
+		// avoid time.Duration overflow on far-future NotAfter dates and to
+		// stay accurate for sub-day lifetimes.
+		totalSecs := cert.Certificate.NotAfter.Unix() - cert.Certificate.NotBefore.Unix()
+		remainingSecs := cert.Certificate.NotAfter.Unix() - time.Now().Unix()
+		ratio := 0.0
+		if totalSecs > 0 {
+			ratio = float64(remainingSecs) / float64(totalSecs)
+		}
 		if ratio > 1 {
 			ratio = 1
 		}

--- a/internal/model/view.go
+++ b/internal/model/view.go
@@ -304,10 +304,12 @@ func (m Model) renderTabContent(width int) string {
 			b.WriteString(m.Styles.BadgeWarning.Render(fmt.Sprintf("  ⚠ Exceeds CA/B max lifetime (%d days)", certificate.CABMaxSubscriberValidityDays)) + "\n")
 		}
 
-		// Expiry progress bar
+		// Life-remaining bar. Fills with the fraction of the lifetime still
+		// left, matching the list's expiry bar (full = healthy) so the two
+		// bars never read in opposite directions.
 		totalLife := cert.Certificate.NotAfter.Sub(cert.Certificate.NotBefore).Hours() / 24
-		elapsed := time.Since(cert.Certificate.NotBefore).Hours() / 24
-		ratio := elapsed / math.Max(totalLife, 1)
+		remaining := time.Until(cert.Certificate.NotAfter).Hours() / 24
+		ratio := remaining / math.Max(totalLife, 1)
 		if ratio > 1 {
 			ratio = 1
 		}
@@ -318,7 +320,7 @@ func (m Model) renderTabContent(width int) string {
 		filled := int(ratio * float64(barWidth))
 		bar := m.Styles.ProgressFull.Render(strings.Repeat("█", filled)) +
 			m.Styles.ProgressEmpty.Render(strings.Repeat("░", barWidth-filled))
-		pct := fmt.Sprintf(" %.0f%% elapsed", ratio*100)
+		pct := fmt.Sprintf(" %.0f%% left", ratio*100)
 		b.WriteString("  " + bar + m.Styles.Dimmed.Render(pct) + "\n")
 
 	case "SANs":


### PR DESCRIPTION
The list's mini expiry bar filled with the time **remaining** (full = healthy), while the Validity tab's bar filled with the time **elapsed** (full = old). The same █/░ glyphs meant opposite things depending on where you looked.

Switch the Validity tab bar to show the fraction of lifetime left (`% left`), so both bars read the same way: a full green bar means a healthy cert in both places.