### PR TITLE
Join the two panes with T-junctions

### DIFF
--- a/internal/model/view.go
+++ b/internal/model/view.go
@@ -229,17 +229,18 @@ func (m Model) renderRightPane(width, height int) string {
 	// The left pane draws no right border, so the right pane's left edge is
 	// the shared divider. Use T-junctions where it meets the top and bottom
 	// rules instead of a second rounded corner butting against the left one.
-	return paneStyle.Border(seamBorder()).Width(width).Height(height).Render(paneContent)
+	return paneStyle.Border(seamBorder).Width(width).Height(height).Render(paneContent)
 }
 
 // seamBorder is a rounded border whose left corners are T-junctions, used by
-// the right pane so the divider between the two panes joins cleanly.
-func seamBorder() lipgloss.Border {
+// the right pane so the divider between the two panes joins cleanly. Built
+// once, since View runs on every frame.
+var seamBorder = func() lipgloss.Border {
 	b := lipgloss.RoundedBorder()
 	b.TopLeft = "┬"
 	b.BottomLeft = "┴"
 	return b
-}
+}()
 
 // renderTabs renders the UI for switching between detail tabs with underline indicator
 func (m Model) renderTabs(_ int) string {

--- a/internal/model/view.go
+++ b/internal/model/view.go
@@ -234,13 +234,14 @@ func (m Model) renderRightPane(width, height int) string {
 
 // seamBorder is a rounded border whose left corners are T-junctions, used by
 // the right pane so the divider between the two panes joins cleanly. Built
-// once, since View runs on every frame.
-var seamBorder = func() lipgloss.Border {
-	b := lipgloss.RoundedBorder()
-	b.TopLeft = "┬"
-	b.BottomLeft = "┴"
-	return b
-}()
+// once at init, since View runs on every frame.
+var seamBorder lipgloss.Border
+
+func init() {
+	seamBorder = lipgloss.RoundedBorder()
+	seamBorder.TopLeft = "┬"
+	seamBorder.BottomLeft = "┴"
+}
 
 // renderTabs renders the UI for switching between detail tabs with underline indicator
 func (m Model) renderTabs(_ int) string {

--- a/internal/model/view.go
+++ b/internal/model/view.go
@@ -234,13 +234,14 @@ func (m Model) renderRightPane(width, height int) string {
 
 // seamBorder is a rounded border whose left corners are T-junctions, used by
 // the right pane so the divider between the two panes joins cleanly. Built
-// once at init, since View runs on every frame.
-var seamBorder lipgloss.Border
+// once at package load, since View runs on every frame.
+var seamBorder = newSeamBorder()
 
-func init() {
-	seamBorder = lipgloss.RoundedBorder()
-	seamBorder.TopLeft = "┬"
-	seamBorder.BottomLeft = "┴"
+func newSeamBorder() lipgloss.Border {
+	b := lipgloss.RoundedBorder()
+	b.TopLeft = "┬"
+	b.BottomLeft = "┴"
+	return b
 }
 
 // renderTabs renders the UI for switching between detail tabs with underline indicator

--- a/internal/model/view.go
+++ b/internal/model/view.go
@@ -226,7 +226,19 @@ func (m Model) renderRightPane(width, height int) string {
 	if m.focus == FocusRight {
 		paneStyle = m.Styles.PaneFocus
 	}
-	return paneStyle.Width(width).Height(height).Render(paneContent)
+	// The left pane draws no right border, so the right pane's left edge is
+	// the shared divider. Use T-junctions where it meets the top and bottom
+	// rules instead of a second rounded corner butting against the left one.
+	return paneStyle.Border(seamBorder()).Width(width).Height(height).Render(paneContent)
+}
+
+// seamBorder is a rounded border whose left corners are T-junctions, used by
+// the right pane so the divider between the two panes joins cleanly.
+func seamBorder() lipgloss.Border {
+	b := lipgloss.RoundedBorder()
+	b.TopLeft = "┬"
+	b.BottomLeft = "┴"
+	return b
 }
 
 // renderTabs renders the UI for switching between detail tabs with underline indicator


### PR DESCRIPTION
The seam between the list and detail panes showed two rounded corners butting together because each pane drew its own rounded box:

```
╭───────────────╭───────────────╮
...
╰───────────────╰───────────────╯
```

The right pane's left edge is the shared divider (the left pane draws no right border), so give it T-junction corners where it meets the top and bottom rules:

```
╭───────────────┬───────────────╮
...
╰───────────────┴───────────────╯
```

No geometry change, only the corner glyphs.