### PR TITLE
fix(model): route huh's own messages so the export popup can submit

### DIFF
--- a/internal/model/update.go
+++ b/internal/model/update.go
@@ -107,6 +107,17 @@ func (m Model) updateExportForm(msg tea.Msg) (tea.Model, tea.Cmd) {
 	}
 	m.exportForm = updated
 
+	// huh sets StateAborted when the form's own quit binding fires. y509
+	// intercepts ctrl+c before it reaches the form, so today that state comes
+	// only from huh's internals, but if the form ever aborts we must tear the
+	// popup down rather than leaving it on screen, unresponsive.
+	if m.exportForm.State == huh.StateAborted {
+		m.exportForm = nil
+		m.viewMode = ViewNormal
+		m.popupType = PopupNone
+		return m, cmd
+	}
+
 	if m.exportForm.State != huh.StateCompleted {
 		return m, cmd
 	}

--- a/internal/model/update.go
+++ b/internal/model/update.go
@@ -23,6 +23,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		logger.Log.Debug("window size updated",
 			zap.Int("width", m.width),
 			zap.Int("height", m.height))
+		if m.exportFormOpen() {
+			return m.updateExportForm(msg)
+		}
 		return m, nil
 
 	case tea.MouseWheelMsg:
@@ -70,7 +73,44 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 	}
 
+	// huh drives the export form through its own messages (nextFieldMsg,
+	// nextGroupMsg, ...), which it returns as commands. They come back here as
+	// plain tea.Msg values, so the form only ever advances a field or reaches
+	// StateCompleted if we hand them back to it.
+	if m.exportFormOpen() {
+		return m.updateExportForm(msg)
+	}
+
 	return m, nil
+}
+
+// exportFormOpen reports whether the huh-driven export popup is on screen.
+func (m Model) exportFormOpen() bool {
+	return m.viewMode == ViewPopup && m.popupType == PopupExport && m.exportForm != nil
+}
+
+// updateExportForm feeds a message to the export form and, once the form is
+// complete, performs the export.
+func (m Model) updateExportForm(msg tea.Msg) (tea.Model, tea.Cmd) {
+	form, cmd := m.exportForm.Update(msg)
+	if f, ok := form.(*huh.Form); ok {
+		m.exportForm = f
+	}
+
+	if m.exportForm.State != huh.StateCompleted {
+		return m, cmd
+	}
+
+	filename := m.exportForm.GetString("filename")
+	format := m.exportForm.GetString("format")
+	// filepath.Ext only inspects the final path component, so paths like
+	// "./out/cert" or "dir.with.dots/cert" still get a suffix.
+	if filename != "" && filepath.Ext(filename) == "" {
+		filename = filename + "." + format
+	}
+	m.exportForm = nil
+	m = m.handleExportCommand(filename)
+	return m, cmd
 }
 
 // updateNormalMode handles key events in normal (two-pane) mode
@@ -242,23 +282,7 @@ func (m Model) updatePopupMode(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			m.exportForm = nil
 			return m, nil
 		}
-		form, cmd := m.exportForm.Update(msg)
-		if f, ok := form.(*huh.Form); ok {
-			m.exportForm = f
-		}
-		if m.exportForm.State == huh.StateCompleted {
-			filename := m.exportForm.GetString("filename")
-			format := m.exportForm.GetString("format")
-			// filepath.Ext only inspects the final path component, so paths
-			// like "./out/cert" or "dir.with.dots/cert" still get a suffix.
-			if filename != "" && filepath.Ext(filename) == "" {
-				filename = filename + "." + format
-			}
-			m.exportForm = nil
-			m = m.handleExportCommand(filename)
-			return m, cmd
-		}
-		return m, cmd
+		return m.updateExportForm(msg)
 	}
 
 	// Handle Input Popups (Search/Filter)

--- a/internal/model/update.go
+++ b/internal/model/update.go
@@ -41,7 +41,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case SplashDoneMsg:
-		m.viewMode = ViewNormal
+		// The splash is also dismissed by any key press, and the timer message
+		// is still in flight when that happens. Only let it retire the splash,
+		// never anything else: a popup opened within the first half-second
+		// would otherwise be torn down, taking whatever was typed into it.
+		if m.viewMode == ViewSplash {
+			m.viewMode = ViewNormal
+		}
 		return m, nil
 
 	case tea.KeyPressMsg:
@@ -93,9 +99,13 @@ func (m Model) exportFormOpen() bool {
 // complete, performs the export.
 func (m Model) updateExportForm(msg tea.Msg) (tea.Model, tea.Cmd) {
 	form, cmd := m.exportForm.Update(msg)
-	if f, ok := form.(*huh.Form); ok {
-		m.exportForm = f
+	updated, ok := form.(*huh.Form)
+	if !ok {
+		// Nothing else huh can return is a form we can drive. Leave the popup
+		// as it was rather than reading state off the copy we no longer hold.
+		return m, cmd
 	}
+	m.exportForm = updated
 
 	if m.exportForm.State != huh.StateCompleted {
 		return m, cmd

--- a/internal/model/update_test.go
+++ b/internal/model/update_test.go
@@ -265,3 +265,38 @@ func pumpKeys(t *testing.T, m Model, keys ...rune) Model {
 	}
 	return m
 }
+
+// TestLateSplashDoneDoesNotClosePopup covers a race: the splash is dismissed by
+// any key, but the 500ms timer message is still in flight. If it retires the
+// splash unconditionally it tears down whatever the user opened in the
+// meantime, discarding their input.
+func TestLateSplashDoneDoesNotClosePopup(t *testing.T) {
+	cfg := loadTestConfig(t)
+	m := *NewModel(createTestCertificates(2), cfg)
+	m = pump(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+
+	if m.viewMode != ViewSplash {
+		t.Fatalf("expected to start on the splash, got %v", m.viewMode)
+	}
+
+	// A key dismisses the splash, and the user immediately opens search.
+	m = pump(t, m, keyPress('x'))
+	m = pump(t, m, keyPress('/'))
+	m = pump(t, m, keyPress('a'))
+
+	if m.viewMode != ViewPopup || m.popupType != PopupSearch {
+		t.Fatalf("expected the search popup to be open, got viewMode=%v popupType=%v",
+			m.viewMode, m.popupType)
+	}
+
+	// Now the splash timer finally fires.
+	m = pump(t, m, SplashDoneMsg{})
+
+	if m.viewMode != ViewPopup || m.popupType != PopupSearch {
+		t.Errorf("a late SplashDoneMsg closed the search popup: viewMode=%v popupType=%v",
+			m.viewMode, m.popupType)
+	}
+	if got := m.textInput.Value(); got != "a" {
+		t.Errorf("the typed query was lost, textInput = %q", got)
+	}
+}

--- a/internal/model/update_test.go
+++ b/internal/model/update_test.go
@@ -300,3 +300,39 @@ func TestLateSplashDoneDoesNotClosePopup(t *testing.T) {
 		t.Errorf("the typed query was lost, textInput = %q", got)
 	}
 }
+
+// TestExportFormAbortClosesPopup checks that an aborted export form tears the
+// popup down instead of leaving it on screen, unresponsive.
+func TestExportFormAbortClosesPopup(t *testing.T) {
+	cfg := loadTestConfig(t)
+	m := *NewModel(createTestCertificates(1), cfg)
+	m = pump(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+	m.viewMode = ViewNormal
+
+	m = pump(t, m, keyPress('e'))
+	if !m.exportFormOpen() {
+		t.Fatal("e did not open the export form")
+	}
+
+	// Abort via the form's own quit binding (ctrl+c). It reaches the form here
+	// because this drives updateExportForm directly, past the Update-level
+	// interception.
+	m = m.updateExportFormModel(t, tea.KeyPressMsg(tea.Key{Code: 'c', Mod: tea.ModCtrl}))
+
+	if m.exportForm != nil {
+		t.Errorf("aborted form was not cleared (state=%v)", m.exportForm.State)
+	}
+	if m.viewMode != ViewNormal || m.popupType != PopupNone {
+		t.Errorf("aborted form left the popup open: viewMode=%v popupType=%v", m.viewMode, m.popupType)
+	}
+}
+
+// updateExportFormModel is a tiny test shim that runs updateExportForm and
+// settles the resulting command, returning the concrete model.
+func (m Model) updateExportFormModel(t *testing.T, msg tea.Msg) Model {
+	t.Helper()
+	next, cmd := m.updateExportForm(msg)
+	out := next.(Model)
+	settle(cmd)
+	return out
+}

--- a/internal/model/update_test.go
+++ b/internal/model/update_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"math/big"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -92,6 +93,102 @@ func TestNavigationKeys(t *testing.T) {
 			t.Errorf("Expected viewport YOffset to decrement, got %d", m.viewport.YOffset())
 		}
 	})
+}
+
+// pump delivers a message to the model and then feeds the resulting commands
+// back in, the way the Bubble Tea runtime does: batches are expanded and the
+// messages they produce are delivered in turn. Components like huh advance
+// their own state through messages they emit as commands, so a test that only
+// calls Update once never exercises the real key path.
+func pump(t *testing.T, m Model, msg tea.Msg) Model {
+	t.Helper()
+
+	queue := []tea.Msg{msg}
+	for delivered := 0; len(queue) > 0 && delivered < 64; delivered++ {
+		next := queue[0]
+		queue = queue[1:]
+
+		updated, cmd := m.Update(next)
+		m = updated.(Model)
+		if cmd == nil {
+			continue
+		}
+
+		switch produced := settle(cmd).(type) {
+		case nil:
+		case tea.BatchMsg:
+			for _, batched := range produced {
+				if out := settle(batched); out != nil {
+					queue = append(queue, out)
+				}
+			}
+		default:
+			queue = append(queue, produced)
+		}
+	}
+	return m
+}
+
+// settle runs a command and returns the message it produced, giving up on any
+// command that does not produce one promptly. Cursor blink ticks sleep on a
+// wall-clock timer before re-arming themselves, so waiting on them would make
+// every keystroke in a test take half a second and never settle.
+func settle(cmd tea.Cmd) tea.Msg {
+	if cmd == nil {
+		return nil
+	}
+
+	produced := make(chan tea.Msg, 1)
+	go func() { produced <- cmd() }()
+
+	select {
+	case msg := <-produced:
+		return msg
+	case <-time.After(50 * time.Millisecond):
+		return nil
+	}
+}
+
+// TestExportFormCompletesThroughUpdate drives the export popup the way a user
+// does: press e, type a filename, confirm the filename field, then confirm the
+// format field. The form only reaches StateCompleted if Update hands huh's own
+// messages back to it.
+func TestExportFormCompletesThroughUpdate(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	cfg := loadTestConfig(t)
+	m := *NewModel(createTestCertificates(1), cfg)
+	m = pump(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+	m.viewMode = ViewNormal
+
+	const target = "out"
+
+	m = pump(t, m, keyPress('e'))
+	if !m.exportFormOpen() {
+		t.Fatal("e did not open the export form")
+	}
+
+	for _, r := range target {
+		m = pump(t, m, keyPress(r))
+	}
+
+	// First enter confirms the filename, second confirms the format select.
+	m = pump(t, m, tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter}))
+	m = pump(t, m, tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter}))
+
+	if m.exportForm != nil {
+		t.Fatalf("export form never completed (huh state = %v)", m.exportForm.State)
+	}
+	if m.popupType != PopupAlert {
+		t.Errorf("expected an alert popup after export, got popupType=%v", m.popupType)
+	}
+	if !strings.Contains(m.popupMessage, "successfully") {
+		t.Errorf("expected a success message, got %q", m.popupMessage)
+	}
+	// The form's default format is PEM, so the extension is appended for us.
+	if _, err := os.Stat(target + ".pem"); err != nil {
+		t.Errorf("expected %s.pem to be written: %v", target, err)
+	}
 }
 
 func TestHelpModeQClosesWithoutQuitting(t *testing.T) {

--- a/internal/model/update_test.go
+++ b/internal/model/update_test.go
@@ -111,23 +111,29 @@ func pump(t *testing.T, m Model, msg tea.Msg) Model {
 
 		updated, cmd := m.Update(next)
 		m = updated.(Model)
-		if cmd == nil {
-			continue
-		}
 
-		switch produced := settle(cmd).(type) {
-		case nil:
-		case tea.BatchMsg:
-			for _, batched := range produced {
-				if out := settle(batched); out != nil {
-					queue = append(queue, out)
-				}
-			}
-		default:
-			queue = append(queue, produced)
-		}
+		queue = append(queue, flatten(settle(cmd))...)
 	}
 	return m
+}
+
+// flatten reduces a produced message to the concrete messages that should be
+// delivered to Update, expanding batches to any depth. Update does not itself
+// understand a tea.BatchMsg, so a nested batch left un-expanded would simply be
+// dropped.
+func flatten(msg tea.Msg) []tea.Msg {
+	switch m := msg.(type) {
+	case nil:
+		return nil
+	case tea.BatchMsg:
+		var out []tea.Msg
+		for _, cmd := range m {
+			out = append(out, flatten(settle(cmd))...)
+		}
+		return out
+	default:
+		return []tea.Msg{m}
+	}
 }
 
 // settle runs a command and returns the message it produced, giving up on any

--- a/internal/model/update_test.go
+++ b/internal/model/update_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/x509/pkix"
 	"math/big"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -154,23 +155,23 @@ func settle(cmd tea.Cmd) tea.Msg {
 // format field. The form only reaches StateCompleted if Update hands huh's own
 // messages back to it.
 func TestExportFormCompletesThroughUpdate(t *testing.T) {
-	t.Chdir(t.TempDir())
-
 	cfg := loadTestConfig(t)
 	m := *NewModel(createTestCertificates(1), cfg)
 	m = pump(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
 	m.viewMode = ViewNormal
 
-	const target = "out"
+	// An absolute path in a temp dir, entered in one paste rather than typed
+	// character by character. Each keystroke otherwise pays the cursor-blink
+	// settle, which a long path makes slow; pasting also keeps the test off the
+	// process working directory, so it stays safe to run in parallel.
+	target := filepath.Join(t.TempDir(), "out")
 
 	m = pump(t, m, keyPress('e'))
 	if !m.exportFormOpen() {
 		t.Fatal("e did not open the export form")
 	}
 
-	for _, r := range target {
-		m = pump(t, m, keyPress(r))
-	}
+	m = pump(t, m, tea.PasteMsg{Content: target})
 
 	// First enter confirms the filename, second confirms the format select.
 	m = pump(t, m, tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter}))


### PR DESCRIPTION
## Problem

The export popup (`e`) can never be submitted. It is a dead key — `esc` is the only way out.

`Update`'s type switch only routes `tea.KeyPressMsg` to the export form. But huh is message-driven: pressing enter in a field makes `Group.Update` return a **command**, which produces a `nextFieldMsg` / `nextGroupMsg`, and `Form.Update` only reaches `StateCompleted` once it *receives* a `nextGroupMsg`. Those messages came back into `Update` as plain `tea.Msg` values, matched no case, and fell through to `return m, nil`.

So the form stays on the Filename field forever, focus never moves to Format, `StateCompleted` never fires, and `handleExportCommand` is never called. The `StateCompleted` block in `updatePopupMode` was unreachable code.

Driving the real event loop before this change:

```text
after 'e':     form != nil
after enter#1: form != nil, huh state = 0 (StateNormal)
after enter#2: form != nil, huh state = 0 (StateNormal)
```

## Fix

Extract the form handling into `updateExportForm` and route *any* message to it while the export popup is open, not just key presses. `tea.WindowSizeMsg` is forwarded too, so the form sizes itself.

## Why this wasn't caught

Every existing export test calls `handleExportCommand` directly, bypassing `Update` entirely — so they passed the whole time. This adds `TestExportFormCompletesThroughUpdate`, which presses `e`, types a filename, and confirms both fields, pumping returned commands back through `Update` the way the Bubble Tea runtime does. Verified it fails against the old routing:

```text
--- FAIL: TestExportFormCompletesThroughUpdate
    update_test.go:180: export form never completed (huh state = 0)
```

`make lint` clean, full suite green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the export popup flow so completion consistently advances the export, uses the selected filename/format, and shows a success confirmation.
  * Automatically adds the selected format extension when the filename has no extension.
  * Prevents a late splash-finish event from dismissing an in-progress popup or view, preserving any typed input.
  * Ensures aborting an export form closes the popup and clears export state.

* **Tests**
  * Added update-flow coverage for successful export (including verifying the generated output file).
  * Added coverage for export abort and for late splash behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->