### PR TITLE
fix(model): keep the alert popup when a filter is rejected

### DIFF
--- a/internal/model/update.go
+++ b/internal/model/update.go
@@ -265,16 +265,22 @@ func (m Model) updatePopupMode(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	switch keyStr {
 	case "enter":
 		value := m.textInput.Value()
-		m.viewMode = ViewNormal // Return to normal mode first
+		submitted := m.popupType
 
-		switch m.popupType {
+		// Dismiss the input popup before dispatching. The handler may raise an
+		// alert of its own -- an unknown filter type does -- and clearing the
+		// popup afterwards would throw that alert away, leaving an empty box on
+		// screen with the error discarded.
+		m.viewMode = ViewNormal
+		m.popupType = PopupNone
+		m.textInput.Reset()
+
+		switch submitted {
 		case PopupSearch:
 			m = m.searchCertificates(value)
 		case PopupFilter:
 			m = m.filterCertificates(value)
 		}
-		m.popupType = PopupNone
-		m.textInput.Reset()
 		return m, nil
 
 	case "esc":

--- a/internal/model/update_test.go
+++ b/internal/model/update_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"math/big"
+	"strings"
 	"testing"
 	"time"
 
@@ -130,4 +131,40 @@ func TestCtrlCQuitsFromSplash(t *testing.T) {
 	if _, ok := cmd().(tea.QuitMsg); !ok {
 		t.Error("ctrl+c on splash did not produce tea.QuitMsg")
 	}
+}
+
+// TestInvalidFilterShowsAlert checks that submitting an unknown filter type
+// surfaces the error. filterCertificates raises a PopupAlert; the enter handler
+// used to clear popupType right after calling it, leaving ViewPopup with no
+// type -- an empty, title-less box, with the message discarded.
+func TestInvalidFilterShowsAlert(t *testing.T) {
+	cfg := loadTestConfig(t)
+	m := *NewModel(createTestCertificates(3), cfg)
+	m.SetDimensions(100, 30)
+	m.viewMode = ViewNormal
+	m.ready = true
+
+	m = pumpKeys(t, m, 'f', 'b', 'o', 'g', 'u', 's')
+	next, _ := m.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter}))
+	m = next.(Model)
+
+	if m.popupType != PopupAlert {
+		t.Fatalf("expected PopupAlert for an unknown filter, got popupType=%v", m.popupType)
+	}
+	if !strings.Contains(m.popupMessage, "Invalid filter type") {
+		t.Errorf("expected the error in popupMessage, got %q", m.popupMessage)
+	}
+	if !strings.Contains(m.View().Content, "Invalid filter type") {
+		t.Error("the invalid-filter error is not rendered on screen")
+	}
+}
+
+// pumpKeys presses each key in turn, discarding commands.
+func pumpKeys(t *testing.T, m Model, keys ...rune) Model {
+	t.Helper()
+	for _, r := range keys {
+		next, _ := m.Update(keyPress(r))
+		m = next.(Model)
+	}
+	return m
 }


### PR DESCRIPTION
## Problem

Typing an unknown filter (`f` → `bogus` → enter) renders an **empty, title-less popup box**, and the error message explaining what went wrong is thrown away.

`filterCertificates` does the right thing — it sets `popupType = PopupAlert` and builds a `popupMessage`. But on return, the enter handler in `updatePopupMode` unconditionally does `m.popupType = PopupNone`, clobbering it. `viewMode` stays `ViewPopup`, so `renderPopup` takes its `default` branch with an empty title and icon and draws the just-`Reset()` text input.

Before this change:

```text
viewMode=ViewPopup  popupType=PopupNone  popupMessage="❌ Invalid filter type: bogus..."
rendered: empty rounded box, no title, a stray "> " prompt
view contains "Invalid filter type"? false
```

## Fix

Dismiss the input popup *before* dispatching to the handler, so a handler that raises its own alert keeps it.

## Why this wasn't caught

`logic_test.go` calls `filterCertificates` directly, where the alert is set correctly — the bug only exists on the key path through `Update`. Added `TestInvalidFilterShowsAlert`, which presses the keys and asserts the error actually reaches the rendered view. It fails against the old handler:

```text
update_test.go:152: expected PopupAlert for an unknown filter, got popupType=0
```

`make lint` clean, full suite green.