### PR TITLE
fix(certificate): number certificates, not PEM blocks

### DIFF
--- a/pkg/certificate/certificate.go
+++ b/pkg/certificate/certificate.go
@@ -404,10 +404,13 @@ func ParseCertificates(data []byte) ([]*Info, error) {
 				Index:       index,
 				Label:       label,
 			})
+			// Count certificates, not PEM blocks: a bundle may also carry a
+			// private key, DH parameters, or a CRL, and those must not consume
+			// a number. Index has to stay equal to the slice position.
+			index++
 		}
 
 		rest = remaining
-		index++
 	}
 
 	if len(certs) == 0 {

--- a/pkg/certificate/load_test.go
+++ b/pkg/certificate/load_test.go
@@ -7,8 +7,10 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
+	"fmt"
 	"math/big"
 	"os"
+	"strings"
 	"testing"
 	"time"
 )
@@ -54,5 +56,61 @@ func TestLoadCertificates_WithPrivateKey(t *testing.T) {
 
 	if len(certs) != 1 {
 		t.Errorf("Expected 1 certificate, got %d", len(certs))
+	}
+}
+
+// TestParseCertificates_NumbersCertificatesNotBlocks pins the invariant that
+// Info.Index equals the slice position and the label counts from 1, even when
+// the bundle carries non-certificate PEM blocks. A key concatenated ahead of
+// the chain used to consume number 1, so the first certificate came out as
+// "2." and every Index was shifted by one.
+func TestParseCertificates_NumbersCertificatesNotBlocks(t *testing.T) {
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	privBytes, err := x509.MarshalECPrivateKey(priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	newCert := func(serial int64, cn string) []byte {
+		template := x509.Certificate{
+			SerialNumber: big.NewInt(serial),
+			Subject:      pkix.Name{CommonName: cn},
+			NotBefore:    time.Now(),
+			NotAfter:     time.Now().Add(time.Hour),
+		}
+		der, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return der
+	}
+
+	// A private key ahead of the chain, and a second one wedged between the
+	// certificates for good measure.
+	var bundle []byte
+	bundle = append(bundle, pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: privBytes})...)
+	bundle = append(bundle, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: newCert(1, "leaf.example.com")})...)
+	bundle = append(bundle, pem.EncodeToMemory(&pem.Block{Type: "DH PARAMETERS", Bytes: []byte("ignored")})...)
+	bundle = append(bundle, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: newCert(2, "intermediate.example.com")})...)
+
+	certs, err := ParseCertificates(bundle)
+	if err != nil {
+		t.Fatalf("ParseCertificates failed: %v", err)
+	}
+	if len(certs) != 2 {
+		t.Fatalf("expected 2 certificates, got %d", len(certs))
+	}
+
+	for i, info := range certs {
+		if info.Index != i {
+			t.Errorf("certificate %d: Index = %d, want %d", i, info.Index, i)
+		}
+		wantPrefix := fmt.Sprintf("%d. ", i+1)
+		if !strings.HasPrefix(info.Label, wantPrefix) {
+			t.Errorf("certificate %d: Label = %q, want it to start with %q", i, info.Label, wantPrefix)
+		}
 	}
 }


### PR DESCRIPTION
## Problem

`ParseCertificates` runs `index++` for every PEM block it decodes, not for every certificate it keeps. Any non-`CERTIFICATE` block in the bundle silently consumes a number.

A `fullchain.pem` with the private key concatenated is the everyday case, and it breaks:

```text
slice=0  Info.Index=1  Label="2. leaf.example.com"
slice=1  Info.Index=3  Label="4. intermediate.example.com"
```

Consequences:

- the TUI list starts numbering at "2."
- `Info.Index` stops matching the slice position, an invariant the rest of the package leans on (`certificate_test.go:110` asserts it, but only for clean input)
- the parse error at the top of the loop reports a *block* number, not a certificate number

## Fix

Move the increment inside the `CERTIFICATE` branch.

## Why this wasn't caught

`TestLoadCertificates_WithPrivateKey` writes the certificate *before* the key, which is the one ordering that happens to work. The new test puts a key ahead of the chain and a `DH PARAMETERS` block between the certificates, then asserts `Index == slice position` and that labels count from 1. It fails against the old loop:

```text
load_test.go:109: certificate 0: Index = 1, want 0
load_test.go:113: certificate 0: Label = "2. leaf.example.com", want it to start with "1. "
```

`make lint` clean, full suite green.