### PR TITLE
fix(cmd): register the --version flag, and report a real version on go install

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -49,6 +49,10 @@ var (
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
+	// Cobra only registers the --version flag when Version is non-empty.
+	// Setting the template alone left --version and -v undefined, even though
+	// the man page and the shell completions both advertised them.
+	RootCmd.Version = version.GetVersion()
 	RootCmd.SetVersionTemplate("y509 version {{.Version}}\nBuild: " + version.GetFullVersion() + "\n")
 
 	if err := RootCmd.Execute(); err != nil {

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -37,11 +37,13 @@ func init() {
 	for _, setting := range info.Settings {
 		switch setting.Key {
 		case "vcs.revision":
-			if GitCommit == "unknown" {
+			// An empty value must not overwrite "unknown" -- it would render as
+			// "y509 version dev ()".
+			if GitCommit == "unknown" && setting.Value != "" {
 				GitCommit = setting.Value
 			}
 		case "vcs.time":
-			if BuildDate == "unknown" {
+			if BuildDate == "unknown" && setting.Value != "" {
 				BuildDate = setting.Value
 			}
 		}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -20,26 +20,30 @@ var (
 // toolchain had already stamped the module version and the VCS revision into
 // the binary. Read them back out.
 func init() {
-	if Version != "dev" {
-		// -ldflags won; leave everything alone.
-		return
-	}
-
 	info, ok := debug.ReadBuildInfo()
 	if !ok {
 		return
 	}
 
-	// "(devel)" is what a build from a local working tree reports.
-	if info.Main.Version != "" && info.Main.Version != "(devel)" {
-		Version = info.Main.Version
+	// Each value falls back on its own. A build that sets only Version through
+	// -ldflags should still pick up the commit and the build time the toolchain
+	// recorded, rather than being left reporting "unknown" for both.
+	if Version == "dev" {
+		// "(devel)" is what a build from a local working tree reports.
+		if info.Main.Version != "" && info.Main.Version != "(devel)" {
+			Version = info.Main.Version
+		}
 	}
 	for _, setting := range info.Settings {
 		switch setting.Key {
 		case "vcs.revision":
-			GitCommit = setting.Value
+			if GitCommit == "unknown" {
+				GitCommit = setting.Value
+			}
 		case "vcs.time":
-			BuildDate = setting.Value
+			if BuildDate == "unknown" {
+				BuildDate = setting.Value
+			}
 		}
 	}
 }

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -2,6 +2,7 @@
 package version
 
 import (
+	"runtime/debug"
 	"strings"
 )
 
@@ -13,6 +14,35 @@ var (
 	// BuildDate is the date the binary was built
 	BuildDate = "unknown"
 )
+
+// Release builds get these values from -ldflags. A `go install` build gets no
+// ldflags at all, so it reported itself as "dev" forever -- even though the
+// toolchain had already stamped the module version and the VCS revision into
+// the binary. Read them back out.
+func init() {
+	if Version != "dev" {
+		// -ldflags won; leave everything alone.
+		return
+	}
+
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return
+	}
+
+	// "(devel)" is what a build from a local working tree reports.
+	if info.Main.Version != "" && info.Main.Version != "(devel)" {
+		Version = info.Main.Version
+	}
+	for _, setting := range info.Settings {
+		switch setting.Key {
+		case "vcs.revision":
+			GitCommit = setting.Value
+		case "vcs.time":
+			BuildDate = setting.Value
+		}
+	}
+}
 
 // GetVersion returns the version string
 func GetVersion() string {


### PR DESCRIPTION
## `--version` did not exist

`Execute` called `SetVersionTemplate` but never set `RootCmd.Version`. Cobra only registers the `--version` flag when `Version` is non-empty, so the template was dead code:

```text
$ y509 --version
Error: unknown flag: --version
$ y509 -v
Error: unknown shorthand flag: 'v' in -v
```

This was the *documented* interface: `man/man1/y509.1`, `completions/y509.bash`, `completions/y509.zsh` and `scripts/brew-test.sh` all advertise `--version` / `-v`. Only the `version` subcommand actually worked, and `brew-test.sh` would fail today.

## `go install` builds reported themselves as `dev`

The version variables come from `-ldflags` at release time, and `go install` passes none. But the toolchain *has* stamped the module version and the VCS revision into the binary — `go version -m` shows them. Read them back out of `debug.ReadBuildInfo()` when ldflags set nothing.

```text
before:  y509 version dev
after:   y509 version v0.12.1-0.20260706091141-6f91c879576a
         Build: v0.12.1-... (6f91c87) built on 2026-07-06T09:11:41Z
```

An `-ldflags` build still wins — the fallback only runs while `Version` is still `"dev"`. Verified both paths:

```text
$ make build && ./y509 version        # ldflags
y509 version v0.12.0-9-g6f91c87

$ go install ./cmd/y509 && y509 version   # no ldflags
y509 version v0.12.1-0.20260706091141-6f91c879576a
```

`make lint` clean, full suite green.