### PR TITLE
feat(certificate): accept DER input

### DIFF
--- a/pkg/certificate/certificate.go
+++ b/pkg/certificate/certificate.go
@@ -379,9 +379,34 @@ func ExportCertificate(cert *x509.Certificate, format string, filename string) e
 	return nil
 }
 
-// ParseCertificates parses PEM blocks and extracts certificates
+// ParseCertificates extracts certificates from a PEM bundle or from raw DER.
+//
+// PEM is tried first. If the input holds no PEM armour at all it is treated as
+// DER, which is what Windows and most CAs hand out as .der / .cer, and what
+// y509's own export writes when asked for DER.
 func ParseCertificates(data []byte) ([]*Info, error) {
-	var certs []*Info
+	certs, sawPEM, err := parsePEMCertificates(data)
+	if err != nil {
+		return nil, err
+	}
+	if len(certs) > 0 {
+		return certs, nil
+	}
+
+	if sawPEM {
+		// The input is PEM, it just holds no certificates -- a lone private key
+		// file, say. Saying "no certificates found" is right, but say why.
+		logger.Error("PEM input contains no CERTIFICATE blocks")
+		return nil, fmt.Errorf("no certificates found in input: the PEM data contains no CERTIFICATE blocks")
+	}
+
+	return parseDERCertificates(data)
+}
+
+// parsePEMCertificates walks the PEM blocks in data. sawPEM reports whether any
+// PEM block at all was present, which tells ParseCertificates whether it is
+// worth retrying the input as DER.
+func parsePEMCertificates(data []byte) (certs []*Info, sawPEM bool, err error) {
 	rest := data
 	index := 0
 
@@ -390,19 +415,19 @@ func ParseCertificates(data []byte) ([]*Info, error) {
 		if block == nil {
 			break
 		}
+		sawPEM = true
 
 		if block.Type == "CERTIFICATE" {
 			crt, err := x509.ParseCertificate(block.Bytes)
 			if err != nil {
 				logger.Error("Failed to parse certificate", zap.Error(err))
-				return nil, fmt.Errorf("failed to parse certificate %d: %w", index, err)
+				return nil, sawPEM, fmt.Errorf("failed to parse certificate %d: %w", index, err)
 			}
 
-			label := generateCertificateLabel(crt, index)
 			certs = append(certs, &Info{
 				Certificate: crt,
 				Index:       index,
-				Label:       label,
+				Label:       generateCertificateLabel(crt, index),
 			})
 			// Count certificates, not PEM blocks: a bundle may also carry a
 			// private key, DH parameters, or a CRL, and those must not consume
@@ -413,13 +438,48 @@ func ParseCertificates(data []byte) ([]*Info, error) {
 		rest = remaining
 	}
 
-	if len(certs) == 0 {
+	return certs, sawPEM, nil
+}
+
+// parseDERCertificates reads the input as raw DER. x509.ParseCertificates
+// handles several certificates concatenated together, which is how a DER chain
+// is usually shipped.
+func parseDERCertificates(data []byte) ([]*Info, error) {
+	parsed, err := x509.ParseCertificates(data)
+	if err != nil {
+		logger.Error("Input is neither PEM nor DER", zap.Error(err))
+
+		// A DER SEQUENCE that is not a certificate is almost always a container
+		// y509 cannot open yet. Say so, rather than claiming there is nothing
+		// there.
+		if len(data) > 0 && data[0] == derSequenceTag {
+			return nil, fmt.Errorf("input is DER but not a certificate "+
+				"(PKCS#7 and PKCS#12 bundles are not supported): %w", err)
+		}
+		return nil, fmt.Errorf("no certificates found in input: not PEM, and not valid DER")
+	}
+
+	// x509.ParseCertificates accepts empty input and returns no certificates
+	// and no error, so the empty case has to be caught here.
+	if len(parsed) == 0 {
 		logger.Error("No certificates found in input")
 		return nil, fmt.Errorf("no certificates found in input")
 	}
 
+	certs := make([]*Info, len(parsed))
+	for i, crt := range parsed {
+		certs[i] = &Info{
+			Certificate: crt,
+			Index:       i,
+			Label:       generateCertificateLabel(crt, i),
+		}
+	}
 	return certs, nil
 }
+
+// derSequenceTag is the ASN.1 universal SEQUENCE tag, the first byte of any
+// DER-encoded certificate, PKCS#7 blob or PKCS#12 bundle.
+const derSequenceTag = 0x30
 
 // generateCertificateLabel creates a display label for the certificate
 func generateCertificateLabel(cert *x509.Certificate, index int) string {

--- a/pkg/certificate/certificate.go
+++ b/pkg/certificate/certificate.go
@@ -447,13 +447,13 @@ func parsePEMCertificates(data []byte) (certs []*Info, sawPEM bool, err error) {
 func parseDERCertificates(data []byte) ([]*Info, error) {
 	parsed, err := x509.ParseCertificates(data)
 	if err != nil {
-		logger.Error("Input is neither PEM nor DER", zap.Error(err))
+		logger.Error("Failed to parse DER input", zap.Error(err))
 
-		// A DER SEQUENCE that is not a certificate is almost always a container
-		// y509 cannot open yet. Say so, rather than claiming there is nothing
-		// there.
+		// The input is a DER structure of some sort but not a certificate. It
+		// is usually a container y509 cannot open yet -- though it may simply
+		// be a corrupt certificate, so do not claim to know which.
 		if len(data) > 0 && data[0] == derSequenceTag {
-			return nil, fmt.Errorf("input is DER but not a certificate "+
+			return nil, fmt.Errorf("input is DER but could not be parsed as a certificate "+
 				"(PKCS#7 and PKCS#12 bundles are not supported): %w", err)
 		}
 		return nil, fmt.Errorf("no certificates found in input: not PEM, and not valid DER")

--- a/pkg/certificate/certificate.go
+++ b/pkg/certificate/certificate.go
@@ -27,6 +27,7 @@ type safeLogger struct {
 	l atomic.Pointer[zap.Logger]
 }
 
+func (s *safeLogger) Debug(msg string, fields ...zap.Field) { s.l.Load().Debug(msg, fields...) }
 func (s *safeLogger) Info(msg string, fields ...zap.Field)  { s.l.Load().Info(msg, fields...) }
 func (s *safeLogger) Warn(msg string, fields ...zap.Field)  { s.l.Load().Warn(msg, fields...) }
 func (s *safeLogger) Error(msg string, fields ...zap.Field) { s.l.Load().Error(msg, fields...) }
@@ -447,16 +448,25 @@ func parsePEMCertificates(data []byte) (certs []*Info, sawPEM bool, err error) {
 func parseDERCertificates(data []byte) ([]*Info, error) {
 	parsed, err := x509.ParseCertificates(data)
 	if err != nil {
-		logger.Error("Failed to parse DER input", zap.Error(err))
+		// Failing to parse is the ordinary outcome for anything that is not a
+		// certificate, so log it at debug rather than spamming the log on every
+		// bad input.
+		logger.Debug("input did not parse as DER certificates", zap.Error(err))
 
-		// The input is a DER structure of some sort but not a certificate. It
-		// is usually a container y509 cannot open yet -- though it may simply
-		// be a corrupt certificate, so do not claim to know which.
-		if len(data) > 0 && data[0] == derSequenceTag {
-			return nil, fmt.Errorf("input is DER but could not be parsed as a certificate "+
+		switch {
+		case isCompleteDERSequence(data):
+			// A well-formed ASN.1 SEQUENCE that is not a certificate is almost
+			// always a container y509 cannot open yet. Testing the first byte
+			// alone would misfire on any text starting with '0' (0x30).
+			return nil, fmt.Errorf("input is a DER structure but not a certificate "+
 				"(PKCS#7 and PKCS#12 bundles are not supported): %w", err)
+		case len(data) > 0 && data[0] == derSequenceTag:
+			// Begins like DER but does not form a complete SEQUENCE: a
+			// truncated or corrupt certificate rather than a container.
+			return nil, fmt.Errorf("input could not be parsed as a certificate: %w", err)
+		default:
+			return nil, fmt.Errorf("no certificates found in input: not PEM, and not valid DER")
 		}
-		return nil, fmt.Errorf("no certificates found in input: not PEM, and not valid DER")
 	}
 
 	// x509.ParseCertificates accepts empty input and returns no certificates
@@ -480,6 +490,17 @@ func parseDERCertificates(data []byte) ([]*Info, error) {
 // derSequenceTag is the ASN.1 universal SEQUENCE tag, the first byte of any
 // DER-encoded certificate, PKCS#7 blob or PKCS#12 bundle.
 const derSequenceTag = 0x30
+
+// isCompleteDERSequence reports whether data is exactly one DER-encoded ASN.1
+// SEQUENCE with no trailing bytes. That is the shape of a certificate, a PKCS#7
+// blob or a PKCS#12 bundle, and -- unlike testing the first byte -- text that
+// merely happens to start with '0' (0x30) does not satisfy it.
+func isCompleteDERSequence(data []byte) bool {
+	var raw asn1.RawValue
+	rest, err := asn1.Unmarshal(data, &raw)
+	return err == nil && len(rest) == 0 &&
+		raw.Class == asn1.ClassUniversal && raw.Tag == asn1.TagSequence
+}
 
 // generateCertificateLabel creates a display label for the certificate
 func generateCertificateLabel(cert *x509.Certificate, index int) string {

--- a/pkg/certificate/certificate.go
+++ b/pkg/certificate/certificate.go
@@ -454,10 +454,10 @@ func parseDERCertificates(data []byte) ([]*Info, error) {
 		logger.Debug("input did not parse as DER certificates", zap.Error(err))
 
 		switch {
-		case isCompleteDERSequence(data):
-			// A well-formed ASN.1 SEQUENCE that is not a certificate is almost
-			// always a container y509 cannot open yet. Testing the first byte
-			// alone would misfire on any text starting with '0' (0x30).
+		case isPKCSContainer(data):
+			// A DER SEQUENCE whose first element is an OID or INTEGER is a PKCS
+			// container, not a certificate. Testing the first byte alone would
+			// misfire on any text starting with '0' (0x30).
 			return nil, fmt.Errorf("input is a DER structure but not a certificate "+
 				"(PKCS#7 and PKCS#12 bundles are not supported): %w", err)
 		case len(data) > 0 && data[0] == derSequenceTag:
@@ -491,15 +491,30 @@ func parseDERCertificates(data []byte) ([]*Info, error) {
 // DER-encoded certificate, PKCS#7 blob or PKCS#12 bundle.
 const derSequenceTag = 0x30
 
-// isCompleteDERSequence reports whether data is exactly one DER-encoded ASN.1
-// SEQUENCE with no trailing bytes. That is the shape of a certificate, a PKCS#7
-// blob or a PKCS#12 bundle, and -- unlike testing the first byte -- text that
-// merely happens to start with '0' (0x30) does not satisfy it.
-func isCompleteDERSequence(data []byte) bool {
-	var raw asn1.RawValue
-	rest, err := asn1.Unmarshal(data, &raw)
-	return err == nil && len(rest) == 0 &&
-		raw.Class == asn1.ClassUniversal && raw.Tag == asn1.TagSequence
+// isPKCSContainer reports whether data looks like a PKCS#7 or PKCS#12 bundle,
+// as opposed to a certificate that merely failed to parse.
+//
+// All three are a single DER SEQUENCE, so the outer shape does not tell them
+// apart; the first element does. A certificate opens with the tbsCertificate
+// SEQUENCE, PKCS#7 with a contentType OID, and PKCS#12 with a version INTEGER.
+// Keying on that keeps a valid certificate that x509 rejected -- an unsupported
+// signature algorithm, say -- from being mislabelled a container.
+func isPKCSContainer(data []byte) bool {
+	var outer asn1.RawValue
+	rest, err := asn1.Unmarshal(data, &outer)
+	if err != nil || len(rest) > 0 ||
+		outer.Class != asn1.ClassUniversal || outer.Tag != asn1.TagSequence {
+		return false
+	}
+
+	var first asn1.RawValue
+	if _, err := asn1.Unmarshal(outer.Bytes, &first); err != nil {
+		return false
+	}
+	if first.Class != asn1.ClassUniversal {
+		return false
+	}
+	return first.Tag == asn1.TagOID || first.Tag == asn1.TagInteger
 }
 
 // generateCertificateLabel creates a display label for the certificate

--- a/pkg/certificate/load_test.go
+++ b/pkg/certificate/load_test.go
@@ -233,6 +233,24 @@ func TestParseCertificates_Errors(t *testing.T) {
 			want:  "could not be parsed as a certificate",
 		},
 		{
+			name: "a cert-shaped SEQUENCE that x509 rejects",
+			// A SEQUENCE whose first element is itself a SEQUENCE looks like a
+			// certificate (tbsCertificate first), not a PKCS container. It must
+			// not be mislabelled one just because x509 could not parse it.
+			input: func() []byte {
+				type inner struct{ A int }
+				der, err := asn1.Marshal(struct {
+					TBS inner
+					N   int
+				}{inner{1}, 2})
+				if err != nil {
+					t.Fatal(err)
+				}
+				return der
+			}(),
+			want: "could not be parsed as a certificate",
+		},
+		{
 			name:  "plain garbage",
 			input: []byte("hello, this is not a certificate"),
 			want:  "not PEM, and not valid DER",

--- a/pkg/certificate/load_test.go
+++ b/pkg/certificate/load_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rand"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/asn1"
 	"encoding/pem"
 	"fmt"
 	"math/big"
@@ -212,9 +213,24 @@ func TestParseCertificates_Errors(t *testing.T) {
 			want:  "no CERTIFICATE blocks",
 		},
 		{
-			name:  "a DER container that is not a certificate",
-			input: []byte{0x30, 0x82, 0x01, 0x02, 0x00, 0x01},
-			want:  "PKCS#7 and PKCS#12",
+			name: "a complete DER SEQUENCE that is not a certificate",
+			// A real, well-formed ASN.1 SEQUENCE that x509 rejects -- standing
+			// in for a PKCS#7 / PKCS#12 container.
+			input: func() []byte {
+				der, err := asn1.Marshal([]int{1, 2, 3})
+				if err != nil {
+					t.Fatal(err)
+				}
+				return der
+			}(),
+			want: "PKCS#7 and PKCS#12",
+		},
+		{
+			name: "text that merely starts with 0x30",
+			// '0' is 0x30, the SEQUENCE tag. The old first-byte test called this
+			// a PKCS container; it is just text.
+			input: []byte("0000 this is plain text, not a certificate at all"),
+			want:  "could not be parsed as a certificate",
 		},
 		{
 			name:  "plain garbage",
@@ -254,6 +270,10 @@ func TestParseCertificates_Errors(t *testing.T) {
 			}
 			if !strings.Contains(err.Error(), tt.want) {
 				t.Errorf("error = %q, want it to mention %q", err, tt.want)
+			}
+			// Only a genuine complete SEQUENCE may be called a PKCS container.
+			if tt.want != "PKCS#7 and PKCS#12" && strings.Contains(err.Error(), "PKCS") {
+				t.Errorf("error = %q wrongly claims a PKCS container", err)
 			}
 		})
 	}

--- a/pkg/certificate/load_test.go
+++ b/pkg/certificate/load_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"math/big"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -112,5 +113,125 @@ func TestParseCertificates_NumbersCertificatesNotBlocks(t *testing.T) {
 		if !strings.HasPrefix(info.Label, wantPrefix) {
 			t.Errorf("certificate %d: Label = %q, want it to start with %q", i, info.Label, wantPrefix)
 		}
+	}
+}
+
+// TestParseCertificates_DER covers raw DER input. y509's own export form offers
+// DER, so before this the tool could write a file it could not read back.
+func TestParseCertificates_DER(t *testing.T) {
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mint := func(serial int64, cn string) []byte {
+		template := x509.Certificate{
+			SerialNumber: big.NewInt(serial),
+			Subject:      pkix.Name{CommonName: cn},
+			NotBefore:    time.Now(),
+			NotAfter:     time.Now().Add(time.Hour),
+		}
+		der, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return der
+	}
+
+	t.Run("single certificate", func(t *testing.T) {
+		certs, err := ParseCertificates(mint(1, "der-leaf"))
+		if err != nil {
+			t.Fatalf("ParseCertificates on DER failed: %v", err)
+		}
+		if len(certs) != 1 {
+			t.Fatalf("expected 1 certificate, got %d", len(certs))
+		}
+		if got := certs[0].Certificate.Subject.CommonName; got != "der-leaf" {
+			t.Errorf("CommonName = %q, want %q", got, "der-leaf")
+		}
+	})
+
+	t.Run("concatenated chain", func(t *testing.T) {
+		var chain []byte
+		chain = append(chain, mint(1, "der-leaf")...)
+		chain = append(chain, mint(2, "der-intermediate")...)
+
+		certs, err := ParseCertificates(chain)
+		if err != nil {
+			t.Fatalf("ParseCertificates on a concatenated DER chain failed: %v", err)
+		}
+		if len(certs) != 2 {
+			t.Fatalf("expected 2 certificates, got %d", len(certs))
+		}
+		for i, info := range certs {
+			if info.Index != i {
+				t.Errorf("certificate %d: Index = %d, want %d", i, info.Index, i)
+			}
+		}
+	})
+
+	t.Run("round trip through ExportCertificate", func(t *testing.T) {
+		cert, err := x509.ParseCertificate(mint(3, "round-trip"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		target := filepath.Join(t.TempDir(), "cert.der")
+		if err := ExportCertificate(cert, "der", target); err != nil {
+			t.Fatalf("ExportCertificate: %v", err)
+		}
+
+		certs, err := LoadCertificates(target)
+		if err != nil {
+			t.Fatalf("could not read back a DER file y509 wrote itself: %v", err)
+		}
+		if len(certs) != 1 || certs[0].Certificate.Subject.CommonName != "round-trip" {
+			t.Errorf("round trip lost the certificate: %+v", certs)
+		}
+	})
+}
+
+// TestParseCertificates_Errors checks that unreadable input says what is wrong
+// rather than the blanket "no certificates found".
+func TestParseCertificates_Errors(t *testing.T) {
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	privBytes, err := x509.MarshalECPrivateKey(priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name  string
+		input []byte
+		want  string
+	}{
+		{
+			name:  "PEM with no certificate blocks",
+			input: pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: privBytes}),
+			want:  "no CERTIFICATE blocks",
+		},
+		{
+			name:  "a DER container that is not a certificate",
+			input: []byte{0x30, 0x82, 0x01, 0x02, 0x00, 0x01},
+			want:  "PKCS#7 and PKCS#12",
+		},
+		{
+			name:  "plain garbage",
+			input: []byte("hello, this is not a certificate"),
+			want:  "not PEM, and not valid DER",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ParseCertificates(tt.input)
+			if err == nil {
+				t.Fatal("expected an error")
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Errorf("error = %q, want it to mention %q", err, tt.want)
+			}
+		})
 	}
 }

--- a/pkg/certificate/load_test.go
+++ b/pkg/certificate/load_test.go
@@ -221,6 +221,29 @@ func TestParseCertificates_Errors(t *testing.T) {
 			input: []byte("hello, this is not a certificate"),
 			want:  "not PEM, and not valid DER",
 		},
+		{
+			name: "a truncated certificate",
+			// A real certificate cut in half is still a DER SEQUENCE, so the
+			// message must not assert it is a PKCS container.
+			input: func() []byte {
+				priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+				if err != nil {
+					t.Fatal(err)
+				}
+				template := x509.Certificate{
+					SerialNumber: big.NewInt(7),
+					Subject:      pkix.Name{CommonName: "truncated"},
+					NotBefore:    time.Now(),
+					NotAfter:     time.Now().Add(time.Hour),
+				}
+				der, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
+				if err != nil {
+					t.Fatal(err)
+				}
+				return der[:len(der)/2]
+			}(),
+			want: "could not be parsed as a certificate",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
> Stacked on #53 — review that first. This PR's own diff is the DER support.

## Problem

`ParseCertificates` only ran `pem.Decode`. A raw DER file failed to load:

```text
$ y509 validate leaf.der
Error: no certificates found in input
```

Two things make this worse than a missing feature:

1. **`CLAUDE.md` claims the package "loads PEM/DER from a file or stdin".** It never did.
2. **y509's own export form offers DER.** The tool could write a file it could not open.

DER is also the default format Windows and most CA portals hand out (`.der` / `.cer`).

## Fix

Try PEM first; fall back to `x509.ParseCertificates` when the input carries no PEM armour at all. That also handles a DER *chain*, which is normally shipped as several certificates concatenated.

## Better errors

Every unreadable input used to get the same blanket "no certificates found in input". Now:

| input | before | after |
| --- | --- | --- |
| a lone private key (PEM) | no certificates found in input | no certificates found in input: the PEM data contains no CERTIFICATE blocks |
| a PKCS#7 / PKCS#12 bundle | no certificates found in input | input is DER but not a certificate (PKCS#7 and PKCS#12 bundles are not supported) |
| plain garbage | no certificates found in input | no certificates found in input: not PEM, and not valid DER |

PKCS#7/#12 remain unsupported — but the error now says so instead of implying the file is empty.

## Verified

Against openssl-produced DER and a real leaf pulled from google.com:

```text
$ openssl x509 -in leaf.pem -outform DER -out leaf.der
$ y509 validate leaf.der
✅ Certificate chain is valid.

$ y509 validate chain.der         # leaf + CA concatenated
✅ Certificate chain is valid.
```

Tests cover single DER, concatenated DER, a **round trip through `ExportCertificate`** (write DER, read it back), and each of the three error messages.

One subtlety worth flagging: `x509.ParseCertificates` accepts empty input and returns *neither certificates nor an error*, so the empty case had to be caught explicitly. The existing `TestParseCertificates/Empty_input` caught me making exactly that mistake mid-change.

`make lint` clean, full suite green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for loading certificates from raw DER data, including concatenated certificate chains.
  * Improved feedback when inputs contain PEM armor without any actual certificate blocks.
* **Bug Fixes**
  * Certificate exports in DER format can now be loaded successfully, with clearer handling of empty/invalid inputs.
  * More accurate error reporting for non-certificate data and corrupted/truncated DER.
* **Logging**
  * Added additional debug logging to aid diagnosis of certificate parsing failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->