### PR TITLE
feat: fetch the chain from a live server

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,46 @@ go install github.com/kanywst/y509@latest
 ## Usage
 
 ```bash
-y509 cert-chain.pem
-openssl s_client -connect example.com:443 -showcerts | y509
+y509 cert-chain.pem                       # a file (PEM or DER)
+y509 example.com:443                      # a live server
+y509 smtp.example.com:587 --starttls smtp # ...behind STARTTLS
+cat chain.pem | y509                      # stdin
 ```
+
+### Talking to a live server
+
+```bash
+y509 example.com:443
+y509 --connect 10.0.0.1:8443 --servername api.internal
+y509 db.example.com:5432 --starttls postgres
+```
+
+An argument naming an existing file is always read as a file; anything else is
+treated as an address. Pass `--connect` to force it. `--starttls` understands
+`smtp`, `imap` and `postgres`.
+
+The handshake deliberately verifies nothing, because a chain that fails to
+verify is usually the reason you came. Certificates come back **in the order the
+server sent them**, which is not necessarily a valid chain — a server shipping
+its root, or omitting an intermediate, is the classic "works in the browser,
+breaks in curl" bug.
+
+### Validating from a script
+
+`validate` verifies against the system trust store and exits non-zero on
+anything a TLS client would reject, so it can gate CI:
+
+```bash
+y509 validate chain.pem                        # 0 = trusted
+y509 validate example.com:443                  # also checks the hostname
+y509 validate chain.pem --roots internal-ca.pem
+```
+
+| Outcome | Exit | Meaning |
+| :--- | :--: | :--- |
+| trusted | 0 | verifies against the trust anchors |
+| self-anchored | 1 | links up, but its root is not trusted (an internal PKI, or a missing root) |
+| broken | 1 | does not link up: expired, bad signature, missing issuer, wrong hostname |
 
 ## Keybindings
 

--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -2,7 +2,10 @@ package cmd
 
 import (
 	"bytes"
+	"strings"
 	"testing"
+
+	"github.com/spf13/cobra"
 )
 
 func TestRootCommandHelp(t *testing.T) {
@@ -66,5 +69,27 @@ func TestLooksLikeHost(t *testing.T) {
 		if got := looksLikeHost(tt.in); got != tt.want {
 			t.Errorf("looksLikeHost(%q) = %v, want %v", tt.in, got, tt.want)
 		}
+	}
+}
+
+// TestLoadInputRejectsConnectPlusArg checks that supplying both --connect and a
+// positional argument is an error rather than silently ignoring the argument.
+func TestLoadInputRejectsConnectPlusArg(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.Flags().String("connect", "", "")
+	cmd.Flags().String("input", "", "")
+	cmd.Flags().String("servername", "", "")
+	cmd.Flags().String("starttls", "", "")
+	cmd.Flags().Duration("timeout", 0, "")
+	if err := cmd.Flags().Set("connect", "example.com:443"); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := loadInput(cmd, []string{"chain.pem"})
+	if err == nil {
+		t.Fatal("expected an error when both --connect and an argument are given")
+	}
+	if !strings.Contains(err.Error(), "not both") {
+		t.Errorf("error = %q, want it to explain the conflict", err)
 	}
 }

--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -56,7 +56,10 @@ func TestLooksLikeHost(t *testing.T) {
 		{"certs", false},         // a bare word is likelier a mistyped file
 		{"./chain.pem", false},   // path-shaped, even though it has a dot
 		{"/etc/ssl/cert.pem", false},
-		{"chain.pem", true}, // a dot with no separator still reads as host-ish; opens as file only if it exists
+		{"chain.pem", false},   // a cert extension, so a file even when missing
+		{"MISSING.PEM", false}, // extension match is case-insensitive
+		{"bundle.p12", false},
+		{"sub.example.com", true}, // a plain domain is still a host
 		{"", false},
 	}
 	for _, tt := range tests {

--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -42,3 +42,26 @@ func TestCommandStructure(t *testing.T) {
 		}
 	}
 }
+
+func TestLooksLikeHost(t *testing.T) {
+	tests := []struct {
+		in   string
+		want bool
+	}{
+		{"example.com", true},
+		{"example.com:443", true},
+		{"https://example.com", true},
+		{"localhost", true},      // bare word, but the obvious local target
+		{"localhost:8443", true}, // covered by the colon anyway
+		{"certs", false},         // a bare word is likelier a mistyped file
+		{"./chain.pem", false},   // path-shaped, even though it has a dot
+		{"/etc/ssl/cert.pem", false},
+		{"chain.pem", true}, // a dot with no separator still reads as host-ish; opens as file only if it exists
+		{"", false},
+	}
+	for _, tt := range tests {
+		if got := looksLikeHost(tt.in); got != tt.want {
+			t.Errorf("looksLikeHost(%q) = %v, want %v", tt.in, got, tt.want)
+		}
+	}
+}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -208,7 +209,7 @@ func looksLikeHost(target string) bool {
 	// still opens as a file. A stat error that is not "no such file" -- a
 	// permission problem, say -- means something is there, and the user meant
 	// it; let the file path report the real error.
-	if _, err := os.Stat(target); !os.IsNotExist(err) {
+	if _, err := os.Stat(target); !errors.Is(err, os.ErrNotExist) {
 		return false
 	}
 

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -142,6 +142,12 @@ func loadInput(cmd *cobra.Command, args []string) (*input, error) {
 	}
 	explicitConnect := target != ""
 
+	// Both would name a source, and --connect would silently win. Rather than
+	// quietly ignore the argument, say they conflict.
+	if explicitConnect && len(args) > 0 {
+		return nil, fmt.Errorf("give either --connect or a file/host argument, not both")
+	}
+
 	if target == "" && len(args) > 0 {
 		target = args[0]
 	}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -210,6 +210,13 @@ func looksLikeHost(target string) bool {
 		return true
 	}
 
+	// localhost is the one bare word that is far likelier to be a host than a
+	// file -- it is the obvious target for local development, and it carries
+	// neither the dot nor the colon the fallback below looks for.
+	if target == "localhost" {
+		return true
+	}
+
 	// Anything shaped like a path is a path, even a missing one. "./chain.pem"
 	// and "/etc/ssl/cert.pem" both contain a dot, and answering a typo in
 	// either with a failed DNS lookup would be baffling.

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -189,20 +189,35 @@ func connectFromFlags(cmd *cobra.Command, target string) (*certificate.ConnectRe
 
 // looksLikeHost decides whether an argument names a server rather than a file.
 //
-// An existing file always wins, so a file that happens to be called
-// "example.com:443" still opens as a file. Otherwise anything with a scheme, or
-// a dot or a colon in it, is treated as an address -- a bare word like "certs"
-// is far more likely to be a mistyped filename than a hostname, and reporting a
-// failed DNS lookup for it would be baffling.
+// Getting this wrong is worse than it sounds: a mistyped path answered with a
+// DNS failure tells the user nothing about what actually went wrong. So the
+// rule leans towards "file", and only what unambiguously reads as an address
+// goes to the network. --connect forces the issue either way.
 func looksLikeHost(target string) bool {
 	if target == "" {
 		return false
 	}
-	if _, err := os.Stat(target); err == nil {
+
+	// An existing file always wins, so a file genuinely named "example.com:443"
+	// still opens as a file. A stat error that is not "no such file" -- a
+	// permission problem, say -- means something is there, and the user meant
+	// it; let the file path report the real error.
+	if _, err := os.Stat(target); !os.IsNotExist(err) {
 		return false
 	}
+
 	if strings.Contains(target, "://") {
 		return true
 	}
+
+	// Anything shaped like a path is a path, even a missing one. "./chain.pem"
+	// and "/etc/ssl/cert.pem" both contain a dot, and answering a typo in
+	// either with a failed DNS lookup would be baffling.
+	if strings.ContainsAny(target, `/\`) {
+		return false
+	}
+
+	// A bare word like "certs" is far likelier to be a mistyped filename than a
+	// hostname. Require a dot (a domain) or a colon (a port).
 	return strings.ContainsAny(target, ".:")
 }

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -224,7 +224,28 @@ func looksLikeHost(target string) bool {
 		return false
 	}
 
+	// A certificate extension means a file, even a mistyped one that does not
+	// exist. "y509 chian.pem" should report "no such file", not a DNS failure
+	// for a host called chian.pem.
+	if hasCertExtension(target) {
+		return false
+	}
+
 	// A bare word like "certs" is far likelier to be a mistyped filename than a
 	// hostname. Require a dot (a domain) or a colon (a port).
 	return strings.ContainsAny(target, ".:")
+}
+
+// certExtensions are the file suffixes that mean "this is a certificate file",
+// so a missing one is reported as a missing file rather than dialled as a host.
+var certExtensions = []string{".pem", ".crt", ".cer", ".der", ".p7b", ".p7c", ".pfx", ".p12"}
+
+func hasCertExtension(target string) bool {
+	lower := strings.ToLower(target)
+	for _, ext := range certExtensions {
+		if strings.HasSuffix(lower, ext) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -4,6 +4,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/kanywst/y509/internal/config"
@@ -18,13 +19,19 @@ import (
 var (
 	// RootCmd represents the base command when called without any subcommands
 	RootCmd = &cobra.Command{
-		Use:   "y509",
-		Short: "A certificate management tool",
-		Long: `y509 is a certificate management tool that provides functionality for:
-- Viewing certificate information
-- Validating certificate chains
-- Exporting certificates in various formats
-- Managing certificate stores`,
+		Use:   "y509 [file | host:port]",
+		Short: "A TUI for X.509 certificate chains",
+		Long: `y509 opens a certificate chain in a terminal UI.
+
+The chain can come from a file, from stdin, or from a live server:
+
+  y509 chain.pem
+  y509 example.com:443
+  y509 smtp.example.com:587 --starttls smtp
+  openssl s_client -connect example.com:443 -showcerts | y509
+
+An argument that names an existing file is always read as a file. Otherwise it
+is treated as an address; pass --connect to force that.`,
 		PersistentPreRun: func(cmd *cobra.Command, _ []string) {
 			// Initialize logger
 			logFile, err := cmd.Flags().GetString("log-file")
@@ -71,6 +78,13 @@ func init() {
 	RootCmd.PersistentFlags().String("log-file", "", "Path to the log file")
 	RootCmd.PersistentFlags().Bool("debug", false, "Enable debug logging")
 
+	// Persistent, so `validate` and `export` can read from a live server too.
+	RootCmd.PersistentFlags().String("connect", "", "Fetch the chain from a live server (host[:port])")
+	RootCmd.PersistentFlags().String("servername", "", "SNI server name to send (default: the host)")
+	RootCmd.PersistentFlags().String("starttls", "", "Upgrade a plaintext protocol first: "+
+		strings.Join(certificate.StartTLSProtocols, ", "))
+	RootCmd.PersistentFlags().Duration("timeout", certificate.DefaultConnectTimeout, "Timeout for a live connection")
+
 	// Subcommands register themselves in their own init().
 
 	// Handle arguments
@@ -88,27 +102,15 @@ func init() {
 			logger.Log.Error("Failed to load configuration", zap.Error(err))
 			// We don't exit here, as we can run with default settings
 		}
-		var inputFile string
-		if len(args) > 0 {
-			inputFile = args[0]
-		} else {
-			var err error
-			inputFile, err = cmd.Flags().GetString("input")
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "Error getting input flag: %v\n", err)
-				os.Exit(1)
-			}
-		}
 
-		// Load certificates
-		certs, err := certificate.LoadCertificates(inputFile)
+		source, err := loadInput(cmd, args)
 		if err != nil {
 			logger.Log.Error("Failed to load certificates", zap.Error(err))
 			return err
 		}
 
 		// Create and run the TUI
-		model := model.NewModel(certs, cfg)
+		model := model.NewModel(source.Certs, cfg)
 		p := tea.NewProgram(model)
 
 		if _, err := p.Run(); err != nil {
@@ -118,4 +120,89 @@ func init() {
 
 		return nil
 	}
+}
+
+// input is where a command's certificates came from.
+type input struct {
+	// Certs are the certificates, leaf first. When they came from a server this
+	// is the order the server sent them in, which is not necessarily valid.
+	Certs []*certificate.Info
+	// Host is the server that was contacted, empty for a file or stdin. It
+	// gives validate a hostname to check the leaf against, which is the whole
+	// question when you are looking at a live endpoint.
+	Host string
+}
+
+// loadInput decides where the certificates come from: a live server, a file, or
+// stdin.
+func loadInput(cmd *cobra.Command, args []string) (*input, error) {
+	target, err := cmd.Flags().GetString("connect")
+	if err != nil {
+		return nil, err
+	}
+	explicitConnect := target != ""
+
+	if target == "" && len(args) > 0 {
+		target = args[0]
+	}
+
+	if explicitConnect || looksLikeHost(target) {
+		result, err := connectFromFlags(cmd, target)
+		if err != nil {
+			return nil, err
+		}
+		return &input{Certs: result.Certificates, Host: result.ServerName}, nil
+	}
+
+	if target == "" {
+		// Fall back to -i, then to stdin.
+		target, err = cmd.Flags().GetString("input")
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	certs, err := certificate.LoadCertificates(target)
+	if err != nil {
+		return nil, err
+	}
+	return &input{Certs: certs}, nil
+}
+
+// connectFromFlags fetches a chain from a live server.
+func connectFromFlags(cmd *cobra.Command, target string) (*certificate.ConnectResult, error) {
+	var opts certificate.ConnectOptions
+	var err error
+
+	if opts.ServerName, err = cmd.Flags().GetString("servername"); err != nil {
+		return nil, err
+	}
+	if opts.StartTLS, err = cmd.Flags().GetString("starttls"); err != nil {
+		return nil, err
+	}
+	if opts.Timeout, err = cmd.Flags().GetDuration("timeout"); err != nil {
+		return nil, err
+	}
+
+	return certificate.FetchChain(cmd.Context(), target, opts)
+}
+
+// looksLikeHost decides whether an argument names a server rather than a file.
+//
+// An existing file always wins, so a file that happens to be called
+// "example.com:443" still opens as a file. Otherwise anything with a scheme, or
+// a dot or a colon in it, is treated as an address -- a bare word like "certs"
+// is far more likely to be a mistyped filename than a hostname, and reporting a
+// failed DNS lookup for it would be baffling.
+func looksLikeHost(target string) bool {
+	if target == "" {
+		return false
+	}
+	if _, err := os.Stat(target); err == nil {
+		return false
+	}
+	if strings.Contains(target, "://") {
+		return true
+	}
+	return strings.ContainsAny(target, ".:")
 }

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -23,21 +23,14 @@ is simply missing its root -- is reported as self-anchored rather than valid,
 and exits non-zero. Pass --roots to supply your own trust anchors.`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		var inputFile string
-		if len(args) > 0 {
-			inputFile = args[0]
-		} else {
-			inputFile, _ = cmd.Flags().GetString("input")
-		}
-
-		certs, err := certificate.LoadCertificates(inputFile)
+		source, err := loadInput(cmd, args)
 		if err != nil {
 			logger.Log.Error("Error loading certificates", zap.Error(err))
 			return err
 		}
 
-		inputCerts := make([]*x509.Certificate, len(certs))
-		for i, c := range certs {
+		inputCerts := make([]*x509.Certificate, len(source.Certs))
+		for i, c := range source.Certs {
 			inputCerts[i] = c.Certificate
 		}
 
@@ -50,6 +43,12 @@ and exits non-zero. Pass --roots to supply your own trust anchors.`,
 		opts, err := verifyOptionsFromFlags(cmd)
 		if err != nil {
 			return err
+		}
+		// When the chain came off the wire, check it is actually valid for the
+		// host we talked to. That is the question a live endpoint raises, and
+		// it is what a TLS client would ask. An explicit --host still wins.
+		if opts.DNSName == "" {
+			opts.DNSName = source.Host
 		}
 
 		result, err := certificate.VerifyChain(chain, opts)

--- a/pkg/certificate/connect.go
+++ b/pkg/certificate/connect.go
@@ -181,6 +181,11 @@ func normalizeAddress(addr string) (address, host string, err error) {
 	if i := strings.IndexAny(addr, "/?#"); i >= 0 {
 		addr = addr[:i]
 	}
+	// Drop any userinfo. Left in place it becomes part of the host, and both
+	// the DNS lookup and the SNI name go out as "user:pass@example.com".
+	if i := strings.LastIndex(addr, "@"); i >= 0 {
+		addr = addr[i+1:]
+	}
 	if addr == "" {
 		return "", "", fmt.Errorf("no host in address")
 	}
@@ -189,6 +194,12 @@ func normalizeAddress(addr string) (address, host string, err error) {
 	if splitErr != nil {
 		// No port, or an unbracketed IPv6 literal. Assume the former.
 		host, port = addr, DefaultTLSPort
+		// A bracketed literal with no port ("[::1]") lands here with its
+		// brackets still on. They belong to the address syntax, not the host,
+		// and JoinHostPort would add a second pair.
+		if strings.HasPrefix(host, "[") && strings.HasSuffix(host, "]") {
+			host = host[1 : len(host)-1]
+		}
 	}
 	if host == "" {
 		return "", "", fmt.Errorf("no host in address %q", addr)
@@ -231,44 +242,50 @@ func negotiateStartTLS(conn net.Conn, protocol string) error {
 func startTLSSMTP(conn net.Conn) error {
 	reader := bufio.NewReader(conn)
 
-	// Greeting.
-	if err := expectSMTPCode(reader, "220"); err != nil {
-		return err
+	// The greeting is frequently several lines. Every one of them has to be
+	// consumed here, or the leftovers are read back as the answer to EHLO.
+	if err := expectSMTPReply(reader, "220"); err != nil {
+		return fmt.Errorf("greeting: %w", err)
 	}
 
 	if _, err := fmt.Fprintf(conn, "EHLO y509\r\n"); err != nil {
 		return err
 	}
-	// EHLO answers with several 250- lines and a final 250 one.
-	for {
-		line, err := reader.ReadString('\n')
-		if err != nil {
-			return err
-		}
-		if !strings.HasPrefix(line, "250") {
-			return fmt.Errorf("unexpected EHLO response: %s", strings.TrimSpace(line))
-		}
-		if len(line) > 3 && line[3] == ' ' {
-			break
-		}
+	if err := expectSMTPReply(reader, "250"); err != nil {
+		return fmt.Errorf("EHLO: %w", err)
 	}
 
 	if _, err := fmt.Fprintf(conn, "STARTTLS\r\n"); err != nil {
 		return err
 	}
-	return expectSMTPCode(reader, "220")
-}
-
-// expectSMTPCode reads one response and checks its status code.
-func expectSMTPCode(reader *bufio.Reader, code string) error {
-	line, err := reader.ReadString('\n')
-	if err != nil {
-		return err
-	}
-	if !strings.HasPrefix(line, code) {
-		return fmt.Errorf("expected %s, got: %s", code, strings.TrimSpace(line))
+	if err := expectSMTPReply(reader, "220"); err != nil {
+		return fmt.Errorf("STARTTLS: %w", err)
 	}
 	return nil
+}
+
+// expectSMTPReply reads a complete SMTP reply and checks its status code.
+//
+// A reply may span several lines. RFC 5321 marks a continuation with a hyphen
+// in the fourth column ("250-STARTTLS") and the final line with anything else,
+// normally a space ("250 OK"). Reading only the first line leaves the rest in
+// the buffer, where it gets mistaken for the answer to the next command -- so a
+// server with a multi-line greeting broke the exchange before it began.
+func expectSMTPReply(reader *bufio.Reader, code string) error {
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			return err
+		}
+		if !strings.HasPrefix(line, code) {
+			return fmt.Errorf("expected %s, got: %s", code, strings.TrimSpace(line))
+		}
+		// Anything but a hyphen in column four ends the reply. Testing for a
+		// space instead would hang on a bare "250\r\n", which is legal.
+		if len(line) < 4 || line[3] != '-' {
+			return nil
+		}
+	}
 }
 
 // startTLSIMAP does the STARTTLS exchange from RFC 3501.
@@ -284,17 +301,27 @@ func startTLSIMAP(conn net.Conn) error {
 		return fmt.Errorf("unexpected greeting: %s", strings.TrimSpace(line))
 	}
 
-	if _, err := fmt.Fprintf(conn, "a001 STARTTLS\r\n"); err != nil {
+	const tag = "a001"
+	if _, err := fmt.Fprintf(conn, "%s STARTTLS\r\n", tag); err != nil {
 		return err
 	}
-	line, err = reader.ReadString('\n')
-	if err != nil {
-		return err
+
+	// A server may send untagged responses -- "* CAPABILITY ...", say -- before
+	// the tagged completion. Skip past them to the line that carries our tag,
+	// rather than reading one line and calling anything else a refusal.
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			return err
+		}
+		if !strings.HasPrefix(line, tag+" ") {
+			continue
+		}
+		if !strings.HasPrefix(line, tag+" OK") {
+			return fmt.Errorf("server refused STARTTLS: %s", strings.TrimSpace(line))
+		}
+		return nil
 	}
-	if !strings.HasPrefix(line, "a001 OK") {
-		return fmt.Errorf("server refused STARTTLS: %s", strings.TrimSpace(line))
-	}
-	return nil
 }
 
 // startTLSPostgres sends the SSLRequest packet from the PostgreSQL frontend

--- a/pkg/certificate/connect.go
+++ b/pkg/certificate/connect.go
@@ -123,6 +123,20 @@ func FetchChain(ctx context.Context, addr string, opts ConnectOptions) (*Connect
 		}
 	}
 
+	// The STARTTLS negotiation below reads synchronously and does not watch the
+	// context itself. The deadline bounds it, but an early cancellation would
+	// otherwise wait the deadline out. Close the connection when the context is
+	// done so those reads unblock at once; stop the watcher on the normal path.
+	stop := make(chan struct{})
+	defer close(stop)
+	go func() {
+		select {
+		case <-ctx.Done():
+			_ = conn.Close()
+		case <-stop:
+		}
+	}()
+
 	if opts.StartTLS != "" {
 		if err := negotiateStartTLS(conn, opts.StartTLS); err != nil {
 			return nil, fmt.Errorf("STARTTLS (%s) failed: %w", opts.StartTLS, err)
@@ -201,6 +215,10 @@ func normalizeAddress(addr string) (address, host string, err error) {
 		if strings.HasPrefix(host, "[") && strings.HasSuffix(host, "]") {
 			host = host[1 : len(host)-1]
 		}
+	} else if port == "" {
+		// A trailing colon ("example.com:") splits cleanly but leaves an empty
+		// port, which would dial an invalid address. Fall back to the default.
+		port = DefaultTLSPort
 	}
 	if host == "" {
 		return "", "", fmt.Errorf("no host in address %q", addr)

--- a/pkg/certificate/connect.go
+++ b/pkg/certificate/connect.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -112,10 +113,11 @@ func FetchChain(ctx context.Context, addr string, opts ConnectOptions) (*Connect
 		return nil, fmt.Errorf("failed to connect to %s: %w", address, err)
 	}
 	defer func() {
-		// When the context is done, the watcher below has already closed the
-		// connection, so this second close returns "use of closed network
-		// connection". That is expected, not worth warning about.
-		if closeErr := conn.Close(); closeErr != nil && ctx.Err() == nil {
+		// An already-closed connection is expected here: the watcher below
+		// closes it on context cancellation, and a failed handshake or a remote
+		// hang-up can close it too. net.ErrClosed covers all of those, so warn
+		// only on some other, genuinely unexpected close error.
+		if closeErr := conn.Close(); closeErr != nil && !errors.Is(closeErr, net.ErrClosed) {
 			logger.Warn("failed to close connection", zap.Error(closeErr))
 		}
 	}()

--- a/pkg/certificate/connect.go
+++ b/pkg/certificate/connect.go
@@ -112,7 +112,10 @@ func FetchChain(ctx context.Context, addr string, opts ConnectOptions) (*Connect
 		return nil, fmt.Errorf("failed to connect to %s: %w", address, err)
 	}
 	defer func() {
-		if closeErr := conn.Close(); closeErr != nil {
+		// When the context is done, the watcher below has already closed the
+		// connection, so this second close returns "use of closed network
+		// connection". That is expected, not worth warning about.
+		if closeErr := conn.Close(); closeErr != nil && ctx.Err() == nil {
 			logger.Warn("failed to close connection", zap.Error(closeErr))
 		}
 	}()

--- a/pkg/certificate/connect.go
+++ b/pkg/certificate/connect.go
@@ -1,0 +1,326 @@
+package certificate
+
+import (
+	"bufio"
+	"context"
+	"crypto/tls"
+	"encoding/binary"
+	"fmt"
+	"net"
+	"strings"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// DefaultConnectTimeout bounds the whole handshake, including the STARTTLS
+// negotiation that precedes it.
+const DefaultConnectTimeout = 10 * time.Second
+
+// DefaultTLSPort is used when the target carries no port.
+const DefaultTLSPort = "443"
+
+// ConnectOptions configures a live TLS fetch.
+type ConnectOptions struct {
+	// ServerName overrides the SNI value and the name the certificate is
+	// checked against. It defaults to the host part of the address.
+	ServerName string
+	// StartTLS names the application protocol to negotiate an upgrade in
+	// before the TLS handshake: smtp, imap, or postgres. Empty means the
+	// connection is TLS from the first byte.
+	StartTLS string
+	// Timeout bounds the whole operation. Zero means DefaultConnectTimeout.
+	Timeout time.Duration
+}
+
+// ConnectResult is what a server presented.
+type ConnectResult struct {
+	// Certificates are the certificates the server sent, in the order it sent
+	// them. That order is not necessarily a valid chain, and preserving it is
+	// the point: a server shipping them out of order, shipping its root, or
+	// omitting an intermediate is exactly the bug worth seeing.
+	Certificates []*Info
+	// Address is the host:port that was dialled.
+	Address string
+	// ServerName is the SNI value that was sent.
+	ServerName string
+	// Version is the negotiated TLS version.
+	Version uint16
+	// CipherSuite is the negotiated cipher suite.
+	CipherSuite uint16
+	// OCSPStapled reports whether the server stapled an OCSP response.
+	OCSPStapled bool
+}
+
+// TLSVersionName renders the negotiated version.
+func (r *ConnectResult) TLSVersionName() string {
+	switch r.Version {
+	case tls.VersionTLS13:
+		return "TLS 1.3"
+	case tls.VersionTLS12:
+		return "TLS 1.2"
+	case tls.VersionTLS11:
+		return "TLS 1.1"
+	case tls.VersionTLS10:
+		return "TLS 1.0"
+	default:
+		return fmt.Sprintf("unknown (0x%04x)", r.Version)
+	}
+}
+
+// FetchChain connects to addr and returns the certificates the server presents.
+//
+// The handshake deliberately does not verify anything: a chain that fails to
+// verify is precisely what the user is trying to look at, so rejecting it at
+// the transport would defeat the purpose. Verification is a separate step, via
+// VerifyChain.
+func FetchChain(ctx context.Context, addr string, opts ConnectOptions) (*ConnectResult, error) {
+	address, host, err := normalizeAddress(addr)
+	if err != nil {
+		return nil, err
+	}
+
+	// Reject an unknown protocol before dialling. Otherwise a typo in
+	// --starttls surfaces as whatever the connection happens to do first, which
+	// is rarely the actual problem.
+	if opts.StartTLS != "" && !supportedStartTLS(opts.StartTLS) {
+		return nil, fmt.Errorf("unsupported --starttls protocol %q (supported: %s)",
+			opts.StartTLS, strings.Join(StartTLSProtocols, ", "))
+	}
+
+	serverName := opts.ServerName
+	if serverName == "" {
+		serverName = host
+	}
+
+	timeout := opts.Timeout
+	if timeout <= 0 {
+		timeout = DefaultConnectTimeout
+	}
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	logger.Info("connecting",
+		zap.String("address", address),
+		zap.String("serverName", serverName),
+		zap.String("startTLS", opts.StartTLS))
+
+	dialer := &net.Dialer{}
+	conn, err := dialer.DialContext(ctx, "tcp", address)
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to %s: %w", address, err)
+	}
+	defer func() {
+		if closeErr := conn.Close(); closeErr != nil {
+			logger.Warn("failed to close connection", zap.Error(closeErr))
+		}
+	}()
+
+	if deadline, ok := ctx.Deadline(); ok {
+		if err := conn.SetDeadline(deadline); err != nil {
+			return nil, fmt.Errorf("failed to set deadline: %w", err)
+		}
+	}
+
+	if opts.StartTLS != "" {
+		if err := negotiateStartTLS(conn, opts.StartTLS); err != nil {
+			return nil, fmt.Errorf("STARTTLS (%s) failed: %w", opts.StartTLS, err)
+		}
+	}
+
+	// InsecureSkipVerify is deliberate: showing a chain the system does not
+	// trust is the whole job. VerifyChain is what passes judgement.
+	tlsConn := tls.Client(conn, &tls.Config{
+		ServerName:         serverName,
+		InsecureSkipVerify: true, //nolint:gosec // see above; this tool inspects untrusted chains by design
+		MinVersion:         tls.VersionTLS10,
+	})
+
+	if err := tlsConn.HandshakeContext(ctx); err != nil {
+		return nil, fmt.Errorf("TLS handshake with %s failed: %w", address, err)
+	}
+
+	state := tlsConn.ConnectionState()
+	if len(state.PeerCertificates) == 0 {
+		return nil, fmt.Errorf("%s presented no certificates", address)
+	}
+
+	certs := make([]*Info, len(state.PeerCertificates))
+	for i, cert := range state.PeerCertificates {
+		certs[i] = &Info{
+			Certificate: cert,
+			Index:       i,
+			Label:       generateCertificateLabel(cert, i),
+		}
+	}
+
+	return &ConnectResult{
+		Certificates: certs,
+		Address:      address,
+		ServerName:   serverName,
+		Version:      state.Version,
+		CipherSuite:  state.CipherSuite,
+		OCSPStapled:  len(state.OCSPResponse) > 0,
+	}, nil
+}
+
+// normalizeAddress turns the many ways a user names a server into a host:port
+// pair, and returns the bare host for SNI. It accepts "example.com",
+// "example.com:8443", "https://example.com/path", and IPv6 literals.
+func normalizeAddress(addr string) (address, host string, err error) {
+	addr = strings.TrimSpace(addr)
+	if addr == "" {
+		return "", "", fmt.Errorf("no address given")
+	}
+
+	// Tolerate a pasted URL.
+	if i := strings.Index(addr, "://"); i >= 0 {
+		addr = addr[i+3:]
+	}
+	addr = strings.TrimSuffix(addr, "/")
+	if i := strings.IndexAny(addr, "/?#"); i >= 0 {
+		addr = addr[:i]
+	}
+	if addr == "" {
+		return "", "", fmt.Errorf("no host in address")
+	}
+
+	host, port, splitErr := net.SplitHostPort(addr)
+	if splitErr != nil {
+		// No port, or an unbracketed IPv6 literal. Assume the former.
+		host, port = addr, DefaultTLSPort
+	}
+	if host == "" {
+		return "", "", fmt.Errorf("no host in address %q", addr)
+	}
+
+	return net.JoinHostPort(host, port), host, nil
+}
+
+// StartTLSProtocols are the application protocols FetchChain can upgrade.
+var StartTLSProtocols = []string{"smtp", "imap", "postgres"}
+
+// supportedStartTLS reports whether negotiateStartTLS knows the protocol.
+func supportedStartTLS(protocol string) bool {
+	switch strings.ToLower(protocol) {
+	case "smtp", "imap", "postgres", "postgresql":
+		return true
+	default:
+		return false
+	}
+}
+
+// negotiateStartTLS performs the plaintext prelude that asks the server to
+// switch to TLS. Each protocol spells this differently, which is exactly why
+// openssl s_client needs a flag for it too.
+func negotiateStartTLS(conn net.Conn, protocol string) error {
+	switch strings.ToLower(protocol) {
+	case "smtp":
+		return startTLSSMTP(conn)
+	case "imap":
+		return startTLSIMAP(conn)
+	case "postgres", "postgresql":
+		return startTLSPostgres(conn)
+	default:
+		return fmt.Errorf("unsupported protocol %q (supported: %s)",
+			protocol, strings.Join(StartTLSProtocols, ", "))
+	}
+}
+
+// startTLSSMTP does the EHLO / STARTTLS exchange from RFC 3207.
+func startTLSSMTP(conn net.Conn) error {
+	reader := bufio.NewReader(conn)
+
+	// Greeting.
+	if err := expectSMTPCode(reader, "220"); err != nil {
+		return err
+	}
+
+	if _, err := fmt.Fprintf(conn, "EHLO y509\r\n"); err != nil {
+		return err
+	}
+	// EHLO answers with several 250- lines and a final 250 one.
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			return err
+		}
+		if !strings.HasPrefix(line, "250") {
+			return fmt.Errorf("unexpected EHLO response: %s", strings.TrimSpace(line))
+		}
+		if len(line) > 3 && line[3] == ' ' {
+			break
+		}
+	}
+
+	if _, err := fmt.Fprintf(conn, "STARTTLS\r\n"); err != nil {
+		return err
+	}
+	return expectSMTPCode(reader, "220")
+}
+
+// expectSMTPCode reads one response and checks its status code.
+func expectSMTPCode(reader *bufio.Reader, code string) error {
+	line, err := reader.ReadString('\n')
+	if err != nil {
+		return err
+	}
+	if !strings.HasPrefix(line, code) {
+		return fmt.Errorf("expected %s, got: %s", code, strings.TrimSpace(line))
+	}
+	return nil
+}
+
+// startTLSIMAP does the STARTTLS exchange from RFC 3501.
+func startTLSIMAP(conn net.Conn) error {
+	reader := bufio.NewReader(conn)
+
+	// Greeting, an untagged * OK line.
+	line, err := reader.ReadString('\n')
+	if err != nil {
+		return err
+	}
+	if !strings.HasPrefix(line, "* OK") {
+		return fmt.Errorf("unexpected greeting: %s", strings.TrimSpace(line))
+	}
+
+	if _, err := fmt.Fprintf(conn, "a001 STARTTLS\r\n"); err != nil {
+		return err
+	}
+	line, err = reader.ReadString('\n')
+	if err != nil {
+		return err
+	}
+	if !strings.HasPrefix(line, "a001 OK") {
+		return fmt.Errorf("server refused STARTTLS: %s", strings.TrimSpace(line))
+	}
+	return nil
+}
+
+// startTLSPostgres sends the SSLRequest packet from the PostgreSQL frontend
+// protocol: an eight byte message whose body is the magic number 80877103.
+// The server answers with a single byte, 'S' to accept or 'N' to refuse.
+func startTLSPostgres(conn net.Conn) error {
+	const sslRequestCode = 80877103
+
+	packet := make([]byte, 8)
+	binary.BigEndian.PutUint32(packet[0:4], 8)
+	binary.BigEndian.PutUint32(packet[4:8], sslRequestCode)
+
+	if _, err := conn.Write(packet); err != nil {
+		return err
+	}
+
+	response := make([]byte, 1)
+	if _, err := conn.Read(response); err != nil {
+		return err
+	}
+	switch response[0] {
+	case 'S':
+		return nil
+	case 'N':
+		return fmt.Errorf("server does not support TLS")
+	default:
+		return fmt.Errorf("unexpected response to SSLRequest: %q", response[0])
+	}
+}

--- a/pkg/certificate/connect.go
+++ b/pkg/certificate/connect.go
@@ -6,6 +6,7 @@ import (
 	"crypto/tls"
 	"encoding/binary"
 	"fmt"
+	"io"
 	"net"
 	"strings"
 	"time"
@@ -339,7 +340,7 @@ func startTLSPostgres(conn net.Conn) error {
 	}
 
 	response := make([]byte, 1)
-	if _, err := conn.Read(response); err != nil {
+	if _, err := io.ReadFull(conn, response); err != nil {
 		return err
 	}
 	switch response[0] {

--- a/pkg/certificate/connect_test.go
+++ b/pkg/certificate/connect_test.go
@@ -215,14 +215,15 @@ func TestFetchChain_Timeout(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = listener.Close() })
 
-	// Accept, then say nothing at all.
+	// Accept, then say nothing at all -- block on a read until the client hangs
+	// up, rather than sleeping, so the goroutine does not outlive the test.
 	go func() {
 		conn, err := listener.Accept()
 		if err != nil {
 			return
 		}
-		<-time.After(30 * time.Second)
-		_ = conn.Close()
+		defer func() { _ = conn.Close() }()
+		_, _ = conn.Read(make([]byte, 1))
 	}()
 
 	start := time.Now()

--- a/pkg/certificate/connect_test.go
+++ b/pkg/certificate/connect_test.go
@@ -341,6 +341,14 @@ func TestNormalizeAddress_Awkward(t *testing.T) {
 			wantHost:    "example.com",
 		},
 		{
+			name: "trailing colon with no port",
+			// net.SplitHostPort accepts this and returns an empty port, which
+			// would dial an invalid address.
+			in:          "example.com:",
+			wantAddress: "example.com:443",
+			wantHost:    "example.com",
+		},
+		{
 			name: "bracketed IPv6 with no port",
 			// The brackets belong to the address syntax, not the host. Kept,
 			// they are sent as the SNI name and JoinHostPort double-wraps them.
@@ -512,5 +520,45 @@ func TestStartTLSIMAP_UntaggedResponses(t *testing.T) {
 				t.Fatal("startTLSIMAP hung")
 			}
 		})
+	}
+}
+
+// TestFetchChain_ContextCancelDuringStartTLS checks that cancelling the context
+// while the STARTTLS negotiation is blocked on a read returns promptly rather
+// than waiting out the deadline.
+func TestFetchChain_ContextCancelDuringStartTLS(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+
+	// Accept and then go silent, so the SMTP greeting read blocks.
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		_, _ = conn.Read(make([]byte, 1))
+	}()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	// A long timeout: if cancellation is not honoured, the read waits this out.
+	_, err = FetchChain(ctx, listener.Addr().String(), ConnectOptions{
+		StartTLS: "smtp",
+		Timeout:  30 * time.Second,
+	})
+	if err == nil {
+		t.Fatal("expected an error from the cancelled context")
+	}
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Errorf("took %v; the cancellation was not honoured during STARTTLS", elapsed)
 	}
 }

--- a/pkg/certificate/connect_test.go
+++ b/pkg/certificate/connect_test.go
@@ -1,0 +1,316 @@
+package certificate
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"errors"
+	"math/big"
+	"net"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestNormalizeAddress(t *testing.T) {
+	tests := []struct {
+		name        string
+		in          string
+		wantAddress string
+		wantHost    string
+		wantErr     bool
+	}{
+		{name: "host and port", in: "example.com:8443", wantAddress: "example.com:8443", wantHost: "example.com"},
+		{name: "bare host defaults to 443", in: "example.com", wantAddress: "example.com:443", wantHost: "example.com"},
+		{name: "https URL", in: "https://example.com", wantAddress: "example.com:443", wantHost: "example.com"},
+		{name: "URL with a path", in: "https://example.com/a/b?c=d", wantAddress: "example.com:443", wantHost: "example.com"},
+		{name: "URL with a port", in: "https://example.com:8443/x", wantAddress: "example.com:8443", wantHost: "example.com"},
+		{name: "IPv4", in: "10.0.0.1:443", wantAddress: "10.0.0.1:443", wantHost: "10.0.0.1"},
+		{name: "bracketed IPv6 with a port", in: "[::1]:8443", wantAddress: "[::1]:8443", wantHost: "::1"},
+		{name: "trailing slash", in: "example.com/", wantAddress: "example.com:443", wantHost: "example.com"},
+		{name: "empty", in: "", wantErr: true},
+		{name: "scheme only", in: "https://", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			address, host, err := normalizeAddress(tt.in)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected an error for %q", tt.in)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("normalizeAddress(%q): %v", tt.in, err)
+			}
+			if address != tt.wantAddress {
+				t.Errorf("address = %q, want %q", address, tt.wantAddress)
+			}
+			if host != tt.wantHost {
+				t.Errorf("host = %q, want %q", host, tt.wantHost)
+			}
+		})
+	}
+}
+
+// testServer starts a TLS listener presenting the given chain, leaf first, and
+// returns its address.
+func testServer(t *testing.T, chain [][]byte, key *ecdsa.PrivateKey) string {
+	t.Helper()
+
+	listener, err := tls.Listen("tcp", "127.0.0.1:0", &tls.Config{
+		Certificates: []tls.Certificate{{Certificate: chain, PrivateKey: key}},
+		MinVersion:   tls.VersionTLS12,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			// The handshake happens on the first read; we don't need the bytes.
+			go func() {
+				defer func() { _ = conn.Close() }()
+				_ = conn.(*tls.Conn).Handshake()
+			}()
+		}
+	}()
+
+	return listener.Addr().String()
+}
+
+// serverChain mints a root and a leaf and returns the DER the server should
+// present, along with the leaf's key.
+func serverChain(t *testing.T, leafCN string) (der [][]byte, leafKey *ecdsa.PrivateKey, root *x509.Certificate) {
+	t.Helper()
+
+	rootKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rootTemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "Test Root CA"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+	rootDER, err := x509.CreateCertificate(rand.Reader, rootTemplate, rootTemplate, &rootKey.PublicKey, rootKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root, err = x509.ParseCertificate(rootDER)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	leafKey, err = ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	leafTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: leafCN},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		DNSNames:     []string{leafCN},
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
+	}
+	leafDER, err := x509.CreateCertificate(rand.Reader, leafTemplate, root, &leafKey.PublicKey, rootKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return [][]byte{leafDER, rootDER}, leafKey, root
+}
+
+// TestFetchChain_PreservesServerOrder checks that the certificates come back in
+// the order the server sent them, leaf first.
+func TestFetchChain_PreservesServerOrder(t *testing.T) {
+	der, key, _ := serverChain(t, "leaf.test")
+	addr := testServer(t, der, key)
+
+	result, err := FetchChain(context.Background(), addr, ConnectOptions{ServerName: "leaf.test"})
+	if err != nil {
+		t.Fatalf("FetchChain: %v", err)
+	}
+
+	if len(result.Certificates) != 2 {
+		t.Fatalf("expected 2 certificates, got %d", len(result.Certificates))
+	}
+	if got := result.Certificates[0].Certificate.Subject.CommonName; got != "leaf.test" {
+		t.Errorf("first certificate = %q, want the leaf %q", got, "leaf.test")
+	}
+	if got := result.Certificates[1].Certificate.Subject.CommonName; got != "Test Root CA" {
+		t.Errorf("second certificate = %q, want %q", got, "Test Root CA")
+	}
+	for i, info := range result.Certificates {
+		if info.Index != i {
+			t.Errorf("certificate %d: Index = %d, want %d", i, info.Index, i)
+		}
+	}
+	if result.Version == 0 {
+		t.Error("no TLS version recorded")
+	}
+}
+
+// TestFetchChain_UntrustedServerStillReturnsTheChain is the point of the
+// feature: a chain the system does not trust is exactly what the user wants to
+// look at, so the handshake must not reject it.
+func TestFetchChain_UntrustedServerStillReturnsTheChain(t *testing.T) {
+	der, key, root := serverChain(t, "leaf.test")
+	addr := testServer(t, der, key)
+
+	result, err := FetchChain(context.Background(), addr, ConnectOptions{ServerName: "leaf.test"})
+	if err != nil {
+		t.Fatalf("FetchChain refused an untrusted chain: %v", err)
+	}
+
+	// The chain came back; now judging it is VerifyChain's job, and it should
+	// say the root is not trusted.
+	chain := make([]*x509.Certificate, len(result.Certificates))
+	for i, info := range result.Certificates {
+		chain[i] = info.Certificate
+	}
+
+	verdict, err := VerifyChain(chain, VerifyOptions{})
+	if err != nil {
+		t.Fatalf("VerifyChain: %v", err)
+	}
+	if verdict.Level != TrustSelfAnchored {
+		t.Errorf("Level = %v, want %v", verdict.Level, TrustSelfAnchored)
+	}
+
+	// And with the root supplied, it verifies.
+	verdict, err = VerifyChain(chain, VerifyOptions{ExtraRoots: []*x509.Certificate{root}})
+	if err != nil {
+		t.Fatalf("VerifyChain: %v", err)
+	}
+	if verdict.Level != TrustAnchored {
+		t.Errorf("with the root trusted: Level = %v (%v), want %v", verdict.Level, verdict.Err, TrustAnchored)
+	}
+}
+
+// TestFetchChain_Timeout checks that a server which never speaks TLS is given
+// up on rather than hanging.
+func TestFetchChain_Timeout(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+
+	// Accept, then say nothing at all.
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		<-time.After(30 * time.Second)
+		_ = conn.Close()
+	}()
+
+	start := time.Now()
+	_, err = FetchChain(context.Background(), listener.Addr().String(), ConnectOptions{
+		Timeout: 200 * time.Millisecond,
+	})
+	if err == nil {
+		t.Fatal("expected a timeout error")
+	}
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Errorf("took %v; the timeout was not honoured", elapsed)
+	}
+}
+
+// TestFetchChain_ConnectionRefused checks the error when nothing is listening.
+func TestFetchChain_ConnectionRefused(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr := listener.Addr().String()
+	if err := listener.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = FetchChain(context.Background(), addr, ConnectOptions{Timeout: time.Second})
+	if err == nil {
+		t.Fatal("expected an error connecting to a closed port")
+	}
+	var opErr *net.OpError
+	if !errors.As(err, &opErr) {
+		t.Logf("error was %v", err)
+	}
+}
+
+// TestNegotiateStartTLS_UnsupportedProtocol checks the error names the ones
+// that do work.
+func TestNegotiateStartTLS_UnsupportedProtocol(t *testing.T) {
+	client, server := net.Pipe()
+	t.Cleanup(func() { _ = client.Close(); _ = server.Close() })
+
+	err := negotiateStartTLS(client, "gopher")
+	if err == nil {
+		t.Fatal("expected an error for an unknown protocol")
+	}
+	for _, supported := range StartTLSProtocols {
+		if !strings.Contains(err.Error(), supported) {
+			t.Errorf("error does not mention the supported protocol %q: %v", supported, err)
+		}
+	}
+}
+
+// TestStartTLSPostgres drives the SSLRequest exchange against a fake server.
+func TestStartTLSPostgres(t *testing.T) {
+	tests := []struct {
+		name    string
+		reply   byte
+		wantErr bool
+	}{
+		{name: "server accepts", reply: 'S', wantErr: false},
+		{name: "server refuses TLS", reply: 'N', wantErr: true},
+		{name: "server says something else", reply: 'X', wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client, server := net.Pipe()
+			t.Cleanup(func() { _ = client.Close() })
+
+			go func() {
+				defer func() { _ = server.Close() }()
+				request := make([]byte, 8)
+				if _, err := server.Read(request); err != nil {
+					return
+				}
+				// The body must be the SSLRequest magic number, 80877103.
+				if request[4] != 0x04 || request[5] != 0xd2 || request[6] != 0x16 || request[7] != 0x2f {
+					t.Errorf("client sent the wrong SSLRequest body: %x", request[4:])
+				}
+				_, _ = server.Write([]byte{tt.reply})
+			}()
+
+			err := startTLSPostgres(client)
+			if tt.wantErr && err == nil {
+				t.Error("expected an error")
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}

--- a/pkg/certificate/connect_test.go
+++ b/pkg/certificate/connect_test.go
@@ -1,6 +1,7 @@
 package certificate
 
 import (
+	"bufio"
 	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
@@ -310,6 +311,204 @@ func TestStartTLSPostgres(t *testing.T) {
 			}
 			if !tt.wantErr && err != nil {
 				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+// TestNormalizeAddress_Awkward covers the shapes that used to come out wrong:
+// a URL carrying userinfo, and a bracketed IPv6 literal with no port.
+func TestNormalizeAddress_Awkward(t *testing.T) {
+	tests := []struct {
+		name        string
+		in          string
+		wantAddress string
+		wantHost    string
+	}{
+		{
+			name: "URL with userinfo",
+			// Left in place, "user:pass@example.com" becomes the host, and goes
+			// out as both the DNS name and the SNI value.
+			in:          "https://user:pass@example.com/admin",
+			wantAddress: "example.com:443",
+			wantHost:    "example.com",
+		},
+		{
+			name:        "userinfo without a scheme",
+			in:          "user@example.com:8443",
+			wantAddress: "example.com:8443",
+			wantHost:    "example.com",
+		},
+		{
+			name: "bracketed IPv6 with no port",
+			// The brackets belong to the address syntax, not the host. Kept,
+			// they are sent as the SNI name and JoinHostPort double-wraps them.
+			in:          "[::1]",
+			wantAddress: "[::1]:443",
+			wantHost:    "::1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			address, host, err := normalizeAddress(tt.in)
+			if err != nil {
+				t.Fatalf("normalizeAddress(%q): %v", tt.in, err)
+			}
+			if address != tt.wantAddress {
+				t.Errorf("address = %q, want %q", address, tt.wantAddress)
+			}
+			if host != tt.wantHost {
+				t.Errorf("host = %q, want %q", host, tt.wantHost)
+			}
+		})
+	}
+}
+
+// fakeLineServer replies with the given script, line by line, to whatever the
+// client sends. It returns the client end of the connection.
+func fakeLineServer(t *testing.T, script []string) net.Conn {
+	t.Helper()
+
+	client, server := net.Pipe()
+	t.Cleanup(func() { _ = client.Close() })
+
+	go func() {
+		defer func() { _ = server.Close() }()
+		reader := bufio.NewReader(server)
+		for _, reply := range script {
+			if reply == "<read>" {
+				if _, err := reader.ReadString('\n'); err != nil {
+					return
+				}
+				continue
+			}
+			if _, err := server.Write([]byte(reply)); err != nil {
+				return
+			}
+		}
+		// Let the client finish reading before the pipe closes.
+		time.Sleep(50 * time.Millisecond)
+	}()
+
+	return client
+}
+
+// TestStartTLSSMTP_MultiLineReplies covers the reply shapes that used to desync
+// the exchange: a multi-line greeting, and an EHLO reply whose last line is a
+// bare code with no trailing space.
+func TestStartTLSSMTP_MultiLineReplies(t *testing.T) {
+	tests := []struct {
+		name    string
+		script  []string
+		wantErr bool
+	}{
+		{
+			name: "multi-line greeting",
+			script: []string{
+				"220-mail.example.com ESMTP Postfix\r\n",
+				"220-This server is monitored\r\n",
+				"220 Ready\r\n",
+				"<read>", // EHLO
+				"250-mail.example.com\r\n",
+				"250-PIPELINING\r\n",
+				"250 STARTTLS\r\n",
+				"<read>", // STARTTLS
+				"220 Go ahead\r\n",
+			},
+		},
+		{
+			name: "EHLO reply ends with a bare code and no space",
+			script: []string{
+				"220 mail.example.com ESMTP\r\n",
+				"<read>",
+				"250-mail.example.com\r\n",
+				"250\r\n", // legal, and used to hang the old loop forever
+				"<read>",
+				"220 Go ahead\r\n",
+			},
+		},
+		{
+			name: "server refuses STARTTLS",
+			script: []string{
+				"220 mail.example.com ESMTP\r\n",
+				"<read>",
+				"250 STARTTLS\r\n",
+				"<read>",
+				"454 TLS not available\r\n",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conn := fakeLineServer(t, tt.script)
+
+			done := make(chan error, 1)
+			go func() { done <- startTLSSMTP(conn) }()
+
+			select {
+			case err := <-done:
+				if tt.wantErr && err == nil {
+					t.Error("expected an error")
+				}
+				if !tt.wantErr && err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+			case <-time.After(3 * time.Second):
+				t.Fatal("startTLSSMTP hung; it did not consume the reply correctly")
+			}
+		})
+	}
+}
+
+// TestStartTLSIMAP_UntaggedResponses covers a compliant server that sends
+// untagged data before the tagged completion of STARTTLS.
+func TestStartTLSIMAP_UntaggedResponses(t *testing.T) {
+	tests := []struct {
+		name    string
+		script  []string
+		wantErr bool
+	}{
+		{
+			name: "untagged responses before the tagged OK",
+			script: []string{
+				"* OK [CAPABILITY IMAP4rev1 STARTTLS] Dovecot ready\r\n",
+				"<read>",
+				"* CAPABILITY IMAP4rev1 STARTTLS\r\n",
+				"* SOMETHING else entirely\r\n",
+				"a001 OK Begin TLS negotiation now\r\n",
+			},
+		},
+		{
+			name: "server refuses",
+			script: []string{
+				"* OK Dovecot ready\r\n",
+				"<read>",
+				"a001 NO TLS is not available\r\n",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conn := fakeLineServer(t, tt.script)
+
+			done := make(chan error, 1)
+			go func() { done <- startTLSIMAP(conn) }()
+
+			select {
+			case err := <-done:
+				if tt.wantErr && err == nil {
+					t.Error("expected an error")
+				}
+				if !tt.wantErr && err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+			case <-time.After(3 * time.Second):
+				t.Fatal("startTLSIMAP hung")
 			}
 		})
 	}


### PR DESCRIPTION
> Stacked on #54 — review that first. This PR's own diff is the connect support.

## Why

y509 could only read from a file or stdin. The README documented the workaround *itself*:

```bash
openssl s_client -connect example.com:443 -showcerts | y509
```

That is a fair sign the feature was missing rather than unwanted. `certigo connect`, `step certificate inspect https://…` and `tlsx` all do this; y509 did not. It is the single biggest capability gap.

## What

```bash
y509 example.com:443
y509 --connect 10.0.0.1:8443 --servername api.internal
y509 db.example.com:5432 --starttls postgres
y509 validate example.com:443
```

New flags (persistent, so `validate` and `export` get them too): `--connect`, `--servername`, `--starttls`, `--timeout`.

## Two design decisions worth reviewing

**1. The handshake sets `InsecureSkipVerify`.** This is deliberate and it is the crux of the thing: *a chain the system does not trust is exactly what the user came to look at.* Rejecting it at the transport would defeat the entire purpose. `VerifyChain` (#54) still passes judgement afterwards, and `validate` still exits non-zero when it should.

**2. Certificates are kept in the order the server sent them**, not sorted on arrival. That order is not necessarily a valid chain — and the ways it can be wrong (a root the server should not have shipped, a missing intermediate) are the bugs worth seeing. openssl's own docs concede that `-showcerts` "displays the server certificate list as sent by the server … it is not a verified chain". This is. Preserving the sent order is also the input a future "as-sent vs verified" view needs.

**3. Connecting makes the hostname a real question**, so `validate` now checks the leaf against the host it dialled unless `--host` overrides. That is what a TLS client does.

## Verified against real servers

badssl.com exists for exactly this, so I used it:

```text
google.com:443                     exit=0   ✅ valid. Trust anchor: GTS Root R1
expired.badssl.com:443             exit=1   ❌ broken — certificate is expired
wrong.host.badssl.com:443          exit=1   ❌ broken — valid for *.badssl.com, not wrong.host.badssl.com
self-signed.badssl.com:443         exit=1   ⚠️  self-anchored
untrusted-root.badssl.com:443      exit=1   ⚠️  self-anchored
127.0.0.1:1                        exit=1   failed to connect: connection refused
```

STARTTLS against a real SMTP server:

```text
$ y509 validate --connect smtp.gmail.com:587 --starttls smtp
✅ Certificate chain is valid.
Trust anchor: GTS Root R1
exit=0
```

A pasted URL works (`y509 validate https://github.com/kanywst/y509`), and a file that happens to be *named* `example.com:443` still opens as a file.

## Tests

Address normalisation (bare host, port, URL with a path, IPv4, bracketed IPv6, empty), a real in-process TLS server asserting the sent order is preserved, an untrusted server whose chain still comes back, timeout, connection refused, and the Postgres `SSLRequest` exchange driven against a fake server (accept / refuse / garbage).

`make lint` clean, `markdownlint` clean, full suite green.