### PR TITLE
feat(certificate): report how the chain was served

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,35 @@ y509 validate chain.pem --roots internal-ca.pem
 | self-anchored | 1 | links up, but its root is not trusted (an internal PKI, or a missing root) |
 | broken | 1 | does not link up: expired, bad signature, missing issuer, wrong hostname |
 
+### How the chain was served
+
+Verifying a chain and *serving it correctly* are different questions, and y509
+answers both. A server can present a chain that your browser accepts and that
+`curl` refuses — because browsers chase the AIA URL to fetch a missing
+intermediate and `curl`, Go and Java do not.
+
+y509 reports that separately, from what was actually sent:
+
+```text
+$ y509 validate incomplete-chain.badssl.com:443
+✅ Certificate chain is valid.
+Trust anchor: ISRG Root X1
+
+Chain as presented:
+  • missing issuer: *.badssl.com
+    the chain stops at a certificate that is not a CA; its issuer "R13" was
+    never sent, so a client that does not chase AIA (curl, Go, Java) cannot
+    build a chain
+    fetch from: http://r13.i.lencr.org/
+```
+
+Note that the chain *verified* — on macOS the platform verifier fetched the
+missing intermediate over the network — and it is still misconfigured. That gap
+is the whole point: the check is structural, so it cannot be papered over.
+
+It also reports a redundant root (a root the server should not be sending),
+certificates sent out of order, duplicates, and strangers in the bundle.
+
 ## Keybindings
 
 |     Key     | Action                                         |

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -34,12 +34,6 @@ and exits non-zero. Pass --roots to supply your own trust anchors.`,
 			inputCerts[i] = c.Certificate
 		}
 
-		chain, err := certificate.SortChain(inputCerts)
-		if err != nil {
-			logger.Log.Error("Failed to sort certificate chain", zap.Error(err))
-			return err
-		}
-
 		opts, err := verifyOptionsFromFlags(cmd)
 		if err != nil {
 			return err
@@ -51,6 +45,16 @@ and exits non-zero. Pass --roots to supply your own trust anchors.`,
 			opts.DNSName = source.Host
 		}
 
+		// Look at the chain as it was presented, before sorting it: sorting is
+		// what destroys the evidence.
+		report := certificate.AnalyzeChain(inputCerts)
+
+		chain, err := certificate.SortChain(inputCerts)
+		if err != nil {
+			logger.Log.Error("Failed to sort certificate chain", zap.Error(err))
+			return err
+		}
+
 		result, err := certificate.VerifyChain(chain, opts)
 		if err != nil {
 			logger.Log.Error("Certificate chain verification failed", zap.Error(err))
@@ -59,9 +63,18 @@ and exits non-zero. Pass --roots to supply your own trust anchors.`,
 
 		fmt.Println(certificate.FormatVerifyResult(result))
 
+		// How the chain was presented is a separate question from whether it
+		// verifies, and a chain can be perfectly trusted while still being
+		// mis-served. Report it either way.
+		if presentation := certificate.FormatChainReport(report); presentation != "" {
+			fmt.Println()
+			fmt.Println(presentation)
+		}
+
 		logger.Log.Info("Certificate chain validation result",
 			zap.String("trust", result.Level.String()),
-			zap.String("anchor", result.Anchor))
+			zap.String("anchor", result.Anchor),
+			zap.Int("presentationFindings", len(report.Findings)))
 
 		// Only a chain that reaches a real trust anchor is a success. A
 		// self-anchored chain gets reported, but a TLS client would not accept

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -46,14 +46,14 @@ and exits non-zero. Pass --roots to supply your own trust anchors.`,
 		}
 
 		// Look at the chain as it was presented, before sorting it: sorting is
-		// what destroys the evidence.
+		// what destroys the evidence. AnalyzeChain sorts it on the way through,
+		// so take its result rather than sorting a second time.
 		report := certificate.AnalyzeChain(inputCerts)
-
-		chain, err := certificate.SortChain(inputCerts)
-		if err != nil {
-			logger.Log.Error("Failed to sort certificate chain", zap.Error(err))
-			return err
+		if report.SortErr != nil {
+			logger.Log.Error("Failed to sort certificate chain", zap.Error(report.SortErr))
+			return report.SortErr
 		}
+		chain := report.Sorted
 
 		result, err := certificate.VerifyChain(chain, opts)
 		if err != nil {

--- a/pkg/certificate/chain.go
+++ b/pkg/certificate/chain.go
@@ -121,6 +121,8 @@ func AnalyzeChain(certs []*x509.Certificate) *ChainReport {
 	report.Sorted = sorted
 	report.SortErr = sortErr
 
+	distinct := countDistinct(certs)
+
 	seen := make(map[string]bool, len(certs))
 	for _, cert := range certs {
 		fingerprint := FormatFingerprint(cert)
@@ -134,7 +136,11 @@ func AnalyzeChain(certs []*x509.Certificate) *ChainReport {
 		}
 		seen[fingerprint] = true
 
-		if cert.Issuer.String() == cert.Subject.String() {
+		// A self-signed certificate is only a redundant root when it sits on top
+		// of a chain. On its own it is the leaf -- a self-signed server
+		// certificate the client has to receive to connect -- and flagging it
+		// would be a false positive.
+		if cert.Issuer.String() == cert.Subject.String() && distinct > 1 {
 			report.Findings = append(report.Findings, ChainFinding{
 				Problem: ProblemRedundantRoot,
 				Subject: displayName(cert),
@@ -204,19 +210,25 @@ func chainTerminus(sorted []*x509.Certificate) *x509.Certificate {
 		return nil
 	}
 
-	subjects := make(map[string]*x509.Certificate, len(sorted))
+	// Index by subject as a list, not a single entry: a cross-signed CA appears
+	// twice under the same subject name, and last-writer-wins would drop one.
+	bySubject := make(map[string][]*x509.Certificate, len(sorted))
 	for _, cert := range sorted {
-		subjects[cert.Subject.String()] = cert
+		subject := cert.Subject.String()
+		bySubject[subject] = append(bySubject[subject], cert)
 	}
 
 	current := sorted[0]
+	// Track visits by fingerprint, not subject name. Keying on the name would
+	// see two distinct certificates that share a subject as a cycle and give up
+	// early, masking a missing issuer further up.
 	visited := make(map[string]bool, len(sorted))
 	for {
-		if visited[current.Subject.String()] {
-			// Cyclic; there is no terminus to speak of.
-			return nil
+		fingerprint := FormatFingerprint(current)
+		if visited[fingerprint] {
+			return nil // genuinely cyclic
 		}
-		visited[current.Subject.String()] = true
+		visited[fingerprint] = true
 
 		if current.Issuer.String() == current.Subject.String() {
 			// Self-signed: the chain ends here, and it is already reported as a
@@ -224,12 +236,38 @@ func chainTerminus(sorted []*x509.Certificate) *x509.Certificate {
 			return nil
 		}
 
-		parent, ok := subjects[current.Issuer.String()]
-		if !ok {
+		parent := findIssuer(current, bySubject[current.Issuer.String()])
+		if parent == nil {
 			return current
 		}
 		current = parent
 	}
+}
+
+// findIssuer picks, from the certificates whose subject matches the child's
+// issuer name, the one that actually signed the child. Name matching alone
+// would follow the wrong link through a cross-signed CA; the signature is the
+// real relationship. It falls back to the first name match so a bundle whose
+// signatures do not verify still terminates rather than looping.
+func findIssuer(child *x509.Certificate, candidates []*x509.Certificate) *x509.Certificate {
+	if len(candidates) == 0 {
+		return nil
+	}
+	for _, candidate := range candidates {
+		if child.CheckSignatureFrom(candidate) == nil {
+			return candidate
+		}
+	}
+	return candidates[0]
+}
+
+// countDistinct counts the certificates with distinct fingerprints.
+func countDistinct(certs []*x509.Certificate) int {
+	seen := make(map[string]bool, len(certs))
+	for _, cert := range certs {
+		seen[FormatFingerprint(cert)] = true
+	}
+	return len(seen)
 }
 
 // unrelatedIn returns the certificates that do not belong to the chain the

--- a/pkg/certificate/chain.go
+++ b/pkg/certificate/chain.go
@@ -3,6 +3,7 @@ package certificate
 import (
 	"crypto/x509"
 	"fmt"
+	"slices"
 	"strings"
 )
 
@@ -100,6 +101,18 @@ func (r *ChainReport) OK() bool { return len(r.Findings) == 0 }
 // people run it from. Asking "what did you send me?" cannot be fooled.
 func AnalyzeChain(certs []*x509.Certificate) *ChainReport {
 	report := &ChainReport{Sent: certs}
+
+	// This is exported, so it does not get to assume a clean slice. Drop nil
+	// entries up front; everything below dereferences a certificate.
+	if slices.Contains(certs, nil) {
+		compact := make([]*x509.Certificate, 0, len(certs))
+		for _, cert := range certs {
+			if cert != nil {
+				compact = append(compact, cert)
+			}
+		}
+		certs = compact
+	}
 	if len(certs) == 0 {
 		return report
 	}
@@ -222,15 +235,30 @@ func chainTerminus(sorted []*x509.Certificate) *x509.Certificate {
 // unrelatedIn returns the certificates that neither issued nor were issued by
 // anything else in the bundle. A single self-signed certificate on its own is
 // not unrelated -- it is the whole chain.
+//
+// Duplicates are collapsed first. Two copies of the same certificate are not
+// each other's issuer, so without this a duplicated leaf would be reported as
+// unrelated -- which it is not; it is a duplicate, and reported as one already.
 func unrelatedIn(certs []*x509.Certificate) []*x509.Certificate {
-	if len(certs) < 2 {
+	unique := make([]*x509.Certificate, 0, len(certs))
+	seen := make(map[string]bool, len(certs))
+	for _, cert := range certs {
+		fingerprint := FormatFingerprint(cert)
+		if seen[fingerprint] {
+			continue
+		}
+		seen[fingerprint] = true
+		unique = append(unique, cert)
+	}
+
+	if len(unique) < 2 {
 		return nil
 	}
 
 	var unrelated []*x509.Certificate
-	for i, cert := range certs {
+	for i, cert := range unique {
 		connected := false
-		for j, other := range certs {
+		for j, other := range unique {
 			if i == j {
 				continue
 			}

--- a/pkg/certificate/chain.go
+++ b/pkg/certificate/chain.go
@@ -100,10 +100,10 @@ func (r *ChainReport) OK() bool { return len(r.Findings) == 0 }
 // "did it verify?" would make the check quietly useless on the platform most
 // people run it from. Asking "what did you send me?" cannot be fooled.
 func AnalyzeChain(certs []*x509.Certificate) *ChainReport {
-	report := &ChainReport{Sent: certs}
-
 	// This is exported, so it does not get to assume a clean slice. Drop nil
-	// entries up front; everything below dereferences a certificate.
+	// entries before anything, including Sent, holds a reference: everything
+	// below -- and every caller reading report.Sent -- dereferences a
+	// certificate.
 	if slices.Contains(certs, nil) {
 		compact := make([]*x509.Certificate, 0, len(certs))
 		for _, cert := range certs {
@@ -113,6 +113,8 @@ func AnalyzeChain(certs []*x509.Certificate) *ChainReport {
 		}
 		certs = compact
 	}
+
+	report := &ChainReport{Sent: certs}
 	if len(certs) == 0 {
 		return report
 	}

--- a/pkg/certificate/chain.go
+++ b/pkg/certificate/chain.go
@@ -232,13 +232,22 @@ func chainTerminus(sorted []*x509.Certificate) *x509.Certificate {
 	}
 }
 
-// unrelatedIn returns the certificates that neither issued nor were issued by
-// anything else in the bundle. A single self-signed certificate on its own is
-// not unrelated -- it is the whole chain.
+// unrelatedIn returns the certificates that do not belong to the chain the
+// primary leaf (the first certificate presented) sits in.
 //
-// Duplicates are collapsed first. Two copies of the same certificate are not
-// each other's issuer, so without this a duplicated leaf would be reported as
-// unrelated -- which it is not; it is a duplicate, and reported as one already.
+// It works by reachability rather than a pairwise "has any neighbour" test.
+// Anything reachable from the leaf by issuer/subject links -- in either
+// direction -- is part of its chain; everything else is baggage. Two things
+// fall out of that:
+//
+//   - The leaf is the starting point, so it is always reachable and can never
+//     be reported as unrelated -- even when its own issuer was not sent, which
+//     is a missing-issuer finding, not an unrelated one.
+//   - A second, disjoint chain is unrelated as a whole, even though its own
+//     members are connected to each other. A pairwise test misses that.
+//
+// Duplicates are collapsed first: two copies of a certificate are not each
+// other's issuer, and a duplicated leaf is already reported as a duplicate.
 func unrelatedIn(certs []*x509.Certificate) []*x509.Certificate {
 	unique := make([]*x509.Certificate, 0, len(certs))
 	seen := make(map[string]bool, len(certs))
@@ -255,24 +264,42 @@ func unrelatedIn(certs []*x509.Certificate) []*x509.Certificate {
 		return nil
 	}
 
+	reachable := reachableFrom(unique[0], unique)
+
 	var unrelated []*x509.Certificate
-	for i, cert := range unique {
-		connected := false
-		for j, other := range unique {
-			if i == j {
-				continue
-			}
-			if cert.Issuer.String() == other.Subject.String() ||
-				other.Issuer.String() == cert.Subject.String() {
-				connected = true
-				break
-			}
-		}
-		if !connected {
+	for _, cert := range unique {
+		if !reachable[FormatFingerprint(cert)] {
 			unrelated = append(unrelated, cert)
 		}
 	}
 	return unrelated
+}
+
+// reachableFrom returns the fingerprints of every certificate reachable from
+// start by issuer/subject links, in either direction. start itself is always
+// included.
+func reachableFrom(start *x509.Certificate, certs []*x509.Certificate) map[string]bool {
+	reached := map[string]bool{FormatFingerprint(start): true}
+	queue := []*x509.Certificate{start}
+
+	for len(queue) > 0 {
+		current := queue[0]
+		queue = queue[1:]
+
+		for _, other := range certs {
+			fingerprint := FormatFingerprint(other)
+			if reached[fingerprint] {
+				continue
+			}
+			if current.Issuer.String() == other.Subject.String() ||
+				other.Issuer.String() == current.Subject.String() {
+				reached[fingerprint] = true
+				queue = append(queue, other)
+			}
+		}
+	}
+
+	return reached
 }
 
 // sameOrder reports whether two chains hold the same certificates in the same

--- a/pkg/certificate/chain.go
+++ b/pkg/certificate/chain.go
@@ -72,6 +72,9 @@ type ChainReport struct {
 	Sent []*x509.Certificate
 	// Sorted is the chain rebuilt leaf-first.
 	Sorted []*x509.Certificate
+	// SortErr is whatever SortChain made of the input. It is carried here so a
+	// caller that needs the sorted chain does not have to sort it a second time.
+	SortErr error
 	// Findings are the problems with how it was presented, in the order they
 	// were discovered.
 	Findings []ChainFinding
@@ -101,8 +104,9 @@ func AnalyzeChain(certs []*x509.Certificate) *ChainReport {
 		return report
 	}
 
-	sorted, _ := SortChain(certs)
+	sorted, sortErr := SortChain(certs)
 	report.Sorted = sorted
+	report.SortErr = sortErr
 
 	seen := make(map[string]bool, len(certs))
 	for _, cert := range certs {
@@ -164,7 +168,10 @@ func AnalyzeChain(certs []*x509.Certificate) *ChainReport {
 		})
 	}
 
-	if !sameOrder(certs, sorted) {
+	// Only meaningful when the chain sorted cleanly. Otherwise `sorted` may not
+	// hold the same certificates, and the comparison would report an ordering
+	// problem that is really a sorting failure.
+	if sortErr == nil && !sameOrder(certs, sorted) {
 		report.Findings = append(report.Findings, ChainFinding{
 			Problem: ProblemOutOfOrder,
 			Subject: displayName(certs[0]),

--- a/pkg/certificate/chain.go
+++ b/pkg/certificate/chain.go
@@ -1,0 +1,293 @@
+package certificate
+
+import (
+	"crypto/x509"
+	"fmt"
+	"strings"
+)
+
+// ChainProblem is something wrong with how a chain was presented, as opposed to
+// something wrong with the certificates themselves.
+type ChainProblem int
+
+const (
+	// ProblemMissingIssuer means a certificate's issuer was not supplied and the
+	// certificate is not self-signed. A TLS client that does not chase the AIA
+	// URL -- which is to say Go, curl and Java, though not the browsers -- will
+	// fail to build a chain. This is the classic "works in Chrome, breaks in
+	// curl" bug.
+	ProblemMissingIssuer ChainProblem = iota
+	// ProblemRedundantRoot means the sender included a self-signed root. Clients
+	// ignore it: they trust their own copy or none at all. It is harmless but
+	// wastes a round trip's worth of bytes on every handshake.
+	ProblemRedundantRoot
+	// ProblemOutOfOrder means the certificates were not sent leaf-first, which
+	// RFC 8446 asks for. Most clients cope; some embedded stacks do not.
+	ProblemOutOfOrder
+	// ProblemDuplicate means the same certificate was sent more than once.
+	ProblemDuplicate
+	// ProblemUnrelated means a certificate belongs to no chain in the bundle.
+	ProblemUnrelated
+)
+
+// String names the problem.
+func (p ChainProblem) String() string {
+	switch p {
+	case ProblemMissingIssuer:
+		return "missing issuer"
+	case ProblemRedundantRoot:
+		return "redundant root"
+	case ProblemOutOfOrder:
+		return "out of order"
+	case ProblemDuplicate:
+		return "duplicate"
+	case ProblemUnrelated:
+		return "unrelated"
+	default:
+		return "unknown"
+	}
+}
+
+// ChainFinding is one problem, tied to the certificate it concerns.
+type ChainFinding struct {
+	// Problem is what is wrong.
+	Problem ChainProblem
+	// Subject is the common name of the certificate concerned.
+	Subject string
+	// Detail explains the finding in a sentence.
+	Detail string
+	// FetchURLs are the AIA CA-Issuers URLs that would supply a missing issuer.
+	// Only set for ProblemMissingIssuer.
+	FetchURLs []string
+}
+
+// ChainReport compares the chain as it was presented against the chain as it
+// should have been.
+//
+// This is the question openssl explicitly declines to answer: its own docs note
+// that s_client -showcerts "displays the server certificate list as sent by the
+// server ... it is not a verified chain".
+type ChainReport struct {
+	// Sent is the chain in the order it was presented.
+	Sent []*x509.Certificate
+	// Sorted is the chain rebuilt leaf-first.
+	Sorted []*x509.Certificate
+	// Findings are the problems with how it was presented, in the order they
+	// were discovered.
+	Findings []ChainFinding
+}
+
+// OK reports whether the chain was presented correctly.
+func (r *ChainReport) OK() bool { return len(r.Findings) == 0 }
+
+// AnalyzeChain compares the chain as presented against the chain as it should
+// have been sent, and reports the difference.
+//
+// certs must be in the order they were presented -- the order a server sent
+// them, or the order they appear in a file. Sorting them first destroys the
+// very information this looks at.
+//
+// The analysis is deliberately structural: it looks only at the certificates
+// that were sent, and never asks a verifier whether the chain builds.
+//
+// That is not squeamishness. On macOS, Go's verification delegates to the
+// platform, which chases the AIA URL and fetches a missing intermediate off the
+// network -- so the very bug this is meant to catch verifies clean. Asking
+// "did it verify?" would make the check quietly useless on the platform most
+// people run it from. Asking "what did you send me?" cannot be fooled.
+func AnalyzeChain(certs []*x509.Certificate) *ChainReport {
+	report := &ChainReport{Sent: certs}
+	if len(certs) == 0 {
+		return report
+	}
+
+	sorted, _ := SortChain(certs)
+	report.Sorted = sorted
+
+	seen := make(map[string]bool, len(certs))
+	for _, cert := range certs {
+		fingerprint := FormatFingerprint(cert)
+		if seen[fingerprint] {
+			report.Findings = append(report.Findings, ChainFinding{
+				Problem: ProblemDuplicate,
+				Subject: displayName(cert),
+				Detail:  "sent more than once",
+			})
+			continue
+		}
+		seen[fingerprint] = true
+
+		if cert.Issuer.String() == cert.Subject.String() {
+			report.Findings = append(report.Findings, ChainFinding{
+				Problem: ProblemRedundantRoot,
+				Subject: displayName(cert),
+				Detail: "a self-signed root was included; clients ignore it and " +
+					"trust their own copy, so it only adds bytes to every handshake",
+			})
+		}
+	}
+
+	// A chain has to terminate at a CA. Whoever is at the top is the last
+	// certificate the sender supplied, and the client is expected to take over
+	// from there using its own trust store.
+	//
+	// If that terminus is not a CA, the sender stopped too early: it never sent
+	// the intermediate that signed the leaf. This is the "works in Chrome,
+	// breaks in curl" bug -- browsers chase the AIA URL and paper over it, but
+	// curl, Go and Java do not.
+	//
+	// If the terminus *is* a CA whose issuer was not sent, that is the normal,
+	// correct shape: the client supplies the root. A cross-signed root like
+	// GTS Root R1 lands here, and must not be flagged.
+	if terminus := chainTerminus(sorted); terminus != nil && !terminus.IsCA {
+		finding := ChainFinding{
+			Problem:   ProblemMissingIssuer,
+			Subject:   displayName(terminus),
+			FetchURLs: terminus.IssuingCertificateURL,
+			Detail: fmt.Sprintf("the chain stops at a certificate that is not a CA; "+
+				"its issuer %q was never sent, so a client that does not chase AIA "+
+				"(curl, Go, Java) cannot build a chain",
+				nameOrUnknown(terminus.Issuer.CommonName)),
+		}
+		if len(finding.FetchURLs) == 0 {
+			finding.Detail += ", and it carries no AIA URL to fetch it from"
+		}
+		report.Findings = append(report.Findings, finding)
+	}
+
+	// A certificate nobody issued and which issued nobody is just baggage.
+	for _, cert := range unrelatedIn(certs) {
+		report.Findings = append(report.Findings, ChainFinding{
+			Problem: ProblemUnrelated,
+			Subject: displayName(cert),
+			Detail:  "belongs to no chain in this bundle",
+		})
+	}
+
+	if !sameOrder(certs, sorted) {
+		report.Findings = append(report.Findings, ChainFinding{
+			Problem: ProblemOutOfOrder,
+			Subject: displayName(certs[0]),
+			Detail: "the certificates were not sent leaf-first; RFC 8446 asks for " +
+				"leaf-first order and some embedded TLS stacks require it",
+		})
+	}
+
+	return report
+}
+
+// chainTerminus walks up from the leaf and returns the last certificate the
+// sender supplied for that chain -- the one whose issuer is absent. It returns
+// nil when the chain is empty or loops.
+func chainTerminus(sorted []*x509.Certificate) *x509.Certificate {
+	if len(sorted) == 0 {
+		return nil
+	}
+
+	subjects := make(map[string]*x509.Certificate, len(sorted))
+	for _, cert := range sorted {
+		subjects[cert.Subject.String()] = cert
+	}
+
+	current := sorted[0]
+	visited := make(map[string]bool, len(sorted))
+	for {
+		if visited[current.Subject.String()] {
+			// Cyclic; there is no terminus to speak of.
+			return nil
+		}
+		visited[current.Subject.String()] = true
+
+		if current.Issuer.String() == current.Subject.String() {
+			// Self-signed: the chain ends here, and it is already reported as a
+			// redundant root.
+			return nil
+		}
+
+		parent, ok := subjects[current.Issuer.String()]
+		if !ok {
+			return current
+		}
+		current = parent
+	}
+}
+
+// unrelatedIn returns the certificates that neither issued nor were issued by
+// anything else in the bundle. A single self-signed certificate on its own is
+// not unrelated -- it is the whole chain.
+func unrelatedIn(certs []*x509.Certificate) []*x509.Certificate {
+	if len(certs) < 2 {
+		return nil
+	}
+
+	var unrelated []*x509.Certificate
+	for i, cert := range certs {
+		connected := false
+		for j, other := range certs {
+			if i == j {
+				continue
+			}
+			if cert.Issuer.String() == other.Subject.String() ||
+				other.Issuer.String() == cert.Subject.String() {
+				connected = true
+				break
+			}
+		}
+		if !connected {
+			unrelated = append(unrelated, cert)
+		}
+	}
+	return unrelated
+}
+
+// sameOrder reports whether two chains hold the same certificates in the same
+// order.
+func sameOrder(a, b []*x509.Certificate) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if !a[i].Equal(b[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+// displayName is the certificate's common name, or its serial if it has none.
+func displayName(cert *x509.Certificate) string {
+	if cert.Subject.CommonName != "" {
+		return cert.Subject.CommonName
+	}
+	return "serial " + cert.SerialNumber.String()
+}
+
+// nameOrUnknown guards against a blank common name in a message.
+func nameOrUnknown(name string) string {
+	if name == "" {
+		return "(no common name)"
+	}
+	return name
+}
+
+// FormatChainReport renders the report for the terminal. It returns an empty
+// string when the chain was presented correctly, so a caller can print it
+// unconditionally.
+func FormatChainReport(report *ChainReport) string {
+	if report == nil || report.OK() {
+		return ""
+	}
+
+	var sb strings.Builder
+	sb.WriteString("Chain as presented:\n")
+
+	for _, finding := range report.Findings {
+		fmt.Fprintf(&sb, "  • %s: %s\n", finding.Problem, finding.Subject)
+		fmt.Fprintf(&sb, "    %s\n", finding.Detail)
+		for _, url := range finding.FetchURLs {
+			fmt.Fprintf(&sb, "    fetch from: %s\n", url)
+		}
+	}
+
+	return strings.TrimRight(sb.String(), "\n")
+}

--- a/pkg/certificate/chain_test.go
+++ b/pkg/certificate/chain_test.go
@@ -174,3 +174,29 @@ func TestFormatChainReport_SilentWhenClean(t *testing.T) {
 		t.Errorf("a clean chain should format to nothing, got:\n%s", got)
 	}
 }
+
+// TestAnalyzeChain_CarriesSortedChain checks the report hands back the sorted
+// chain, so a caller does not have to sort a second time.
+func TestAnalyzeChain_CarriesSortedChain(t *testing.T) {
+	root, rootKey := issue(t, "Root CA", true, nil, nil)
+	intermediate, intermediateKey := issue(t, "Issuing CA", true, root, rootKey)
+	leaf, _ := issue(t, "leaf.example.com", false, intermediate, intermediateKey)
+
+	// Presented backwards.
+	report := AnalyzeChain([]*x509.Certificate{intermediate, leaf})
+
+	if report.SortErr != nil {
+		t.Fatalf("SortErr = %v, want nil", report.SortErr)
+	}
+	if len(report.Sorted) != 2 {
+		t.Fatalf("Sorted holds %d certificates, want 2", len(report.Sorted))
+	}
+	if !report.Sorted[0].Equal(leaf) {
+		t.Errorf("Sorted[0] = %q, want the leaf", report.Sorted[0].Subject.CommonName)
+	}
+	// The sent order is preserved untouched alongside it.
+	if !report.Sent[0].Equal(intermediate) {
+		t.Errorf("Sent[0] = %q, want the intermediate that was actually sent first",
+			report.Sent[0].Subject.CommonName)
+	}
+}

--- a/pkg/certificate/chain_test.go
+++ b/pkg/certificate/chain_test.go
@@ -303,3 +303,51 @@ func TestAnalyzeChain_DisjointSecondChainIsUnrelated(t *testing.T) {
 		t.Error("the primary chain must not be reported as unrelated")
 	}
 }
+
+// TestAnalyzeChain_LoneSelfSignedIsNotRedundant is a regression: a single
+// self-signed certificate is the leaf the server presents, not a redundant
+// root, so it must produce no findings.
+func TestAnalyzeChain_LoneSelfSignedIsNotRedundant(t *testing.T) {
+	selfSigned, _ := issue(t, "self-signed.example.com", true, nil, nil)
+
+	report := AnalyzeChain([]*x509.Certificate{selfSigned})
+	if !report.OK() {
+		t.Errorf("a lone self-signed certificate should be clean, got %v", problemNames(report))
+	}
+}
+
+// TestAnalyzeChain_SelfSignedSentTwiceIsOnlyDuplicate checks that a self-signed
+// certificate sent twice is a duplicate, not a redundant root: there is still
+// only one distinct certificate, and it is the leaf.
+func TestAnalyzeChain_SelfSignedSentTwiceIsOnlyDuplicate(t *testing.T) {
+	selfSigned, _ := issue(t, "self-signed.example.com", true, nil, nil)
+
+	report := AnalyzeChain([]*x509.Certificate{selfSigned, selfSigned})
+	if !hasProblem(report, ProblemDuplicate) {
+		t.Errorf("the repeat should be reported as a duplicate; findings: %v", problemNames(report))
+	}
+	if hasProblem(report, ProblemRedundantRoot) {
+		t.Errorf("a self-signed leaf sent twice is not a redundant root; findings: %v", problemNames(report))
+	}
+}
+
+// TestAnalyzeChain_CrossSignedSameSubjectTerminus checks that a decoy sharing a
+// subject name with the real issuer does not derail the terminus walk. The walk
+// used to key its cycle detection on the subject string, so a second
+// certificate with the same subject looked like a loop and stopped it early.
+func TestAnalyzeChain_CrossSignedSameSubjectTerminus(t *testing.T) {
+	root, rootKey := issue(t, "Root CA", true, nil, nil)
+	intermediate, intermediateKey := issue(t, "Issuing CA", true, root, rootKey)
+	leaf, _ := issue(t, "leaf.example.com", false, intermediate, intermediateKey)
+
+	// A self-signed decoy that shares the root's subject name but signed nothing
+	// in this chain. Keying cycle detection on the subject name would trip over
+	// it. The real terminus is the intermediate, which is a CA -> no finding.
+	decoy, _ := issue(t, "Root CA", true, nil, nil)
+
+	report := AnalyzeChain([]*x509.Certificate{leaf, intermediate, decoy})
+	if hasProblem(report, ProblemMissingIssuer) {
+		t.Errorf("the intermediate is a CA, so no missing issuer should be reported; findings: %v",
+			problemNames(report))
+	}
+}

--- a/pkg/certificate/chain_test.go
+++ b/pkg/certificate/chain_test.go
@@ -1,0 +1,176 @@
+package certificate
+
+import (
+	"crypto/x509"
+	"strings"
+	"testing"
+)
+
+// hasProblem reports whether the report contains a finding of the given kind.
+func hasProblem(report *ChainReport, problem ChainProblem) bool {
+	for _, finding := range report.Findings {
+		if finding.Problem == problem {
+			return true
+		}
+	}
+	return false
+}
+
+func problemNames(report *ChainReport) []string {
+	names := make([]string, 0, len(report.Findings))
+	for _, finding := range report.Findings {
+		names = append(names, finding.Problem.String())
+	}
+	return names
+}
+
+// TestAnalyzeChain_WellFormed is the case that must stay silent: leaf then
+// intermediate, with the root left to the client. This is what a correctly
+// configured server sends.
+func TestAnalyzeChain_WellFormed(t *testing.T) {
+	root, rootKey := issue(t, "Root CA", true, nil, nil)
+	intermediate, intermediateKey := issue(t, "Issuing CA", true, root, rootKey)
+	leaf, _ := issue(t, "leaf.example.com", false, intermediate, intermediateKey)
+
+	report := AnalyzeChain([]*x509.Certificate{leaf, intermediate})
+	if !report.OK() {
+		t.Errorf("a correctly served chain was flagged: %v", problemNames(report))
+	}
+}
+
+// TestAnalyzeChain_MissingIntermediate is the bug worth catching: the server
+// sends only the leaf, so a client that does not chase AIA cannot build a
+// chain. This is the "works in Chrome, breaks in curl" case.
+func TestAnalyzeChain_MissingIntermediate(t *testing.T) {
+	root, rootKey := issue(t, "Root CA", true, nil, nil)
+	intermediate, intermediateKey := issue(t, "Issuing CA", true, root, rootKey)
+	leaf, _ := issue(t, "leaf.example.com", false, intermediate, intermediateKey)
+
+	report := AnalyzeChain([]*x509.Certificate{leaf})
+	if !hasProblem(report, ProblemMissingIssuer) {
+		t.Fatalf("a missing intermediate was not reported; findings: %v", problemNames(report))
+	}
+
+	for _, finding := range report.Findings {
+		if finding.Problem == ProblemMissingIssuer {
+			if !strings.Contains(finding.Detail, "Issuing CA") {
+				t.Errorf("the finding does not name the missing issuer: %q", finding.Detail)
+			}
+		}
+	}
+}
+
+// TestAnalyzeChain_CrossSignedRootIsNotMissingItsIssuer is the false positive to
+// avoid. A cross-signed root sits at the top of the chain with its own issuer
+// absent -- and always will, because the client trusts the root itself. This is
+// what google.com sends (GTS Root R1, issued by GlobalSign Root CA).
+func TestAnalyzeChain_CrossSignedRootIsNotMissingItsIssuer(t *testing.T) {
+	oldRoot, oldRootKey := issue(t, "Legacy Root CA", true, nil, nil)
+	// A CA certificate whose issuer is the legacy root: this is the shape of a
+	// cross-signed root, and its own issuer is never sent.
+	crossSigned, crossSignedKey := issue(t, "Modern Root CA", true, oldRoot, oldRootKey)
+	intermediate, intermediateKey := issue(t, "Issuing CA", true, crossSigned, crossSignedKey)
+	leaf, _ := issue(t, "leaf.example.com", false, intermediate, intermediateKey)
+
+	report := AnalyzeChain([]*x509.Certificate{leaf, intermediate, crossSigned})
+	if hasProblem(report, ProblemMissingIssuer) {
+		t.Errorf("a cross-signed root at the top was wrongly reported as a missing issuer; findings: %v",
+			problemNames(report))
+	}
+}
+
+// TestAnalyzeChain_RedundantRoot covers a server shipping its own root.
+func TestAnalyzeChain_RedundantRoot(t *testing.T) {
+	root, rootKey := issue(t, "Root CA", true, nil, nil)
+	intermediate, intermediateKey := issue(t, "Issuing CA", true, root, rootKey)
+	leaf, _ := issue(t, "leaf.example.com", false, intermediate, intermediateKey)
+
+	report := AnalyzeChain([]*x509.Certificate{leaf, intermediate, root})
+	if !hasProblem(report, ProblemRedundantRoot) {
+		t.Errorf("a self-signed root in the bundle was not reported; findings: %v", problemNames(report))
+	}
+	// It is redundant, not missing.
+	if hasProblem(report, ProblemMissingIssuer) {
+		t.Errorf("shipping the root must not also report a missing issuer; findings: %v",
+			problemNames(report))
+	}
+}
+
+// TestAnalyzeChain_OutOfOrder covers a server sending the intermediate first.
+func TestAnalyzeChain_OutOfOrder(t *testing.T) {
+	root, rootKey := issue(t, "Root CA", true, nil, nil)
+	intermediate, intermediateKey := issue(t, "Issuing CA", true, root, rootKey)
+	leaf, _ := issue(t, "leaf.example.com", false, intermediate, intermediateKey)
+
+	report := AnalyzeChain([]*x509.Certificate{intermediate, leaf})
+	if !hasProblem(report, ProblemOutOfOrder) {
+		t.Errorf("a chain sent intermediate-first was not reported; findings: %v", problemNames(report))
+	}
+}
+
+// TestAnalyzeChain_Duplicate covers the same certificate sent twice.
+func TestAnalyzeChain_Duplicate(t *testing.T) {
+	root, rootKey := issue(t, "Root CA", true, nil, nil)
+	intermediate, intermediateKey := issue(t, "Issuing CA", true, root, rootKey)
+	leaf, _ := issue(t, "leaf.example.com", false, intermediate, intermediateKey)
+
+	report := AnalyzeChain([]*x509.Certificate{leaf, intermediate, intermediate})
+	if !hasProblem(report, ProblemDuplicate) {
+		t.Errorf("a duplicated certificate was not reported; findings: %v", problemNames(report))
+	}
+}
+
+// TestAnalyzeChain_Unrelated covers a certificate that belongs to no chain in
+// the bundle.
+func TestAnalyzeChain_Unrelated(t *testing.T) {
+	root, rootKey := issue(t, "Root CA", true, nil, nil)
+	intermediate, intermediateKey := issue(t, "Issuing CA", true, root, rootKey)
+	leaf, _ := issue(t, "leaf.example.com", false, intermediate, intermediateKey)
+
+	otherRoot, otherRootKey := issue(t, "Unrelated Root", true, nil, nil)
+	stranger, _ := issue(t, "stranger.example.net", false, otherRoot, otherRootKey)
+
+	report := AnalyzeChain([]*x509.Certificate{leaf, intermediate, stranger})
+	if !hasProblem(report, ProblemUnrelated) {
+		t.Errorf("a stranger in the bundle was not reported; findings: %v", problemNames(report))
+	}
+}
+
+// TestAnalyzeChain_SelfSignedAlone covers a single self-signed certificate: it
+// is a redundant root, but nothing is missing and nothing is unrelated.
+func TestAnalyzeChain_SelfSignedAlone(t *testing.T) {
+	selfSigned, _ := issue(t, "self-signed.example.com", true, nil, nil)
+
+	report := AnalyzeChain([]*x509.Certificate{selfSigned})
+	if hasProblem(report, ProblemMissingIssuer) {
+		t.Errorf("a self-signed certificate has no missing issuer; findings: %v", problemNames(report))
+	}
+	if hasProblem(report, ProblemUnrelated) {
+		t.Errorf("a lone self-signed certificate is not unrelated to itself; findings: %v",
+			problemNames(report))
+	}
+}
+
+// TestAnalyzeChain_Empty covers the degenerate input.
+func TestAnalyzeChain_Empty(t *testing.T) {
+	report := AnalyzeChain(nil)
+	if !report.OK() {
+		t.Errorf("an empty chain should produce no findings, got %v", problemNames(report))
+	}
+	if FormatChainReport(report) != "" {
+		t.Error("an empty chain should format to nothing")
+	}
+}
+
+// TestFormatChainReport_SilentWhenClean checks that a clean chain formats to the
+// empty string, so callers can print it unconditionally.
+func TestFormatChainReport_SilentWhenClean(t *testing.T) {
+	root, rootKey := issue(t, "Root CA", true, nil, nil)
+	intermediate, intermediateKey := issue(t, "Issuing CA", true, root, rootKey)
+	leaf, _ := issue(t, "leaf.example.com", false, intermediate, intermediateKey)
+
+	report := AnalyzeChain([]*x509.Certificate{leaf, intermediate})
+	if got := FormatChainReport(report); got != "" {
+		t.Errorf("a clean chain should format to nothing, got:\n%s", got)
+	}
+}

--- a/pkg/certificate/chain_test.go
+++ b/pkg/certificate/chain_test.go
@@ -242,6 +242,19 @@ func TestAnalyzeChain_NilEntries(t *testing.T) {
 			t.Errorf("a slice of only nils should produce no findings, got %v", problemNames(report))
 		}
 	})
+
+	t.Run("Sent carries no nils", func(t *testing.T) {
+		// A caller reading report.Sent must not meet a nil the analysis stripped.
+		report := AnalyzeChain([]*x509.Certificate{leaf, nil, intermediate})
+		for i, cert := range report.Sent {
+			if cert == nil {
+				t.Fatalf("report.Sent[%d] is nil", i)
+			}
+		}
+		if len(report.Sent) != 2 {
+			t.Errorf("report.Sent holds %d certificates, want 2", len(report.Sent))
+		}
+	})
 }
 
 // TestAnalyzeChain_LeafNotFlaggedUnrelated is a regression: when the

--- a/pkg/certificate/chain_test.go
+++ b/pkg/certificate/chain_test.go
@@ -200,3 +200,46 @@ func TestAnalyzeChain_CarriesSortedChain(t *testing.T) {
 			report.Sent[0].Subject.CommonName)
 	}
 }
+
+// TestAnalyzeChain_DuplicateIsNotUnrelated is a regression: two copies of the
+// same certificate are not each other's issuer, so unrelatedIn used to flag a
+// duplicated leaf as unrelated -- twice -- on top of the duplicate finding.
+func TestAnalyzeChain_DuplicateIsNotUnrelated(t *testing.T) {
+	root, rootKey := issue(t, "Root CA", true, nil, nil)
+	intermediate, intermediateKey := issue(t, "Issuing CA", true, root, rootKey)
+	leaf, _ := issue(t, "leaf.example.com", false, intermediate, intermediateKey)
+
+	report := AnalyzeChain([]*x509.Certificate{leaf, leaf})
+
+	if !hasProblem(report, ProblemDuplicate) {
+		t.Errorf("a duplicated leaf should be reported as a duplicate; findings: %v", problemNames(report))
+	}
+	if hasProblem(report, ProblemUnrelated) {
+		t.Errorf("a duplicated leaf must not also be reported as unrelated; findings: %v", problemNames(report))
+	}
+}
+
+// TestAnalyzeChain_NilEntries checks the exported entry point survives nil
+// certificates in the slice rather than panicking on the first dereference.
+func TestAnalyzeChain_NilEntries(t *testing.T) {
+	root, rootKey := issue(t, "Root CA", true, nil, nil)
+	intermediate, intermediateKey := issue(t, "Issuing CA", true, root, rootKey)
+	leaf, _ := issue(t, "leaf.example.com", false, intermediate, intermediateKey)
+
+	t.Run("nil among real certs", func(t *testing.T) {
+		// Dropping the nil leaves a well-formed leaf+intermediate pair, so the
+		// point is simply that it is analyzed without panicking and the nil is
+		// not itself mistaken for a certificate.
+		report := AnalyzeChain([]*x509.Certificate{leaf, nil, intermediate})
+		if !report.OK() {
+			t.Errorf("the leaf+intermediate pair should analyze clean, got %v", problemNames(report))
+		}
+	})
+
+	t.Run("all nil", func(t *testing.T) {
+		report := AnalyzeChain([]*x509.Certificate{nil, nil})
+		if !report.OK() {
+			t.Errorf("a slice of only nils should produce no findings, got %v", problemNames(report))
+		}
+	})
+}

--- a/pkg/certificate/chain_test.go
+++ b/pkg/certificate/chain_test.go
@@ -243,3 +243,63 @@ func TestAnalyzeChain_NilEntries(t *testing.T) {
 		}
 	})
 }
+
+// TestAnalyzeChain_LeafNotFlaggedUnrelated is a regression: when the
+// intermediate is missing, the leaf has no neighbour in the bundle, so the old
+// pairwise check reported the validation target itself as "unrelated" on top of
+// the missing-issuer finding.
+func TestAnalyzeChain_LeafNotFlaggedUnrelated(t *testing.T) {
+	root, rootKey := issue(t, "Root CA", true, nil, nil)
+	intermediate, intermediateKey := issue(t, "Issuing CA", true, root, rootKey)
+	leaf, _ := issue(t, "leaf.example.com", false, intermediate, intermediateKey)
+
+	otherRoot, otherRootKey := issue(t, "Other Root", true, nil, nil)
+	stranger, _ := issue(t, "stranger.net", false, otherRoot, otherRootKey)
+
+	// The intermediate is absent, so the leaf connects to nothing.
+	report := AnalyzeChain([]*x509.Certificate{leaf, stranger})
+
+	if !hasProblem(report, ProblemMissingIssuer) {
+		t.Errorf("the missing intermediate should be reported; findings: %v", problemNames(report))
+	}
+	for _, finding := range report.Findings {
+		if finding.Problem == ProblemUnrelated && finding.Subject == "leaf.example.com" {
+			t.Error("the primary leaf must never be reported as unrelated")
+		}
+	}
+	// The stranger, on the other hand, is genuinely unrelated.
+	if !hasProblem(report, ProblemUnrelated) {
+		t.Errorf("the stranger should be reported as unrelated; findings: %v", problemNames(report))
+	}
+}
+
+// TestAnalyzeChain_DisjointSecondChainIsUnrelated checks that a whole second
+// chain -- whose members are connected to each other but not to the primary
+// leaf -- is reported as unrelated. A pairwise "has any neighbour" test misses
+// this, because each member has a neighbour within its own chain.
+func TestAnalyzeChain_DisjointSecondChainIsUnrelated(t *testing.T) {
+	root, rootKey := issue(t, "Root CA", true, nil, nil)
+	intermediate, intermediateKey := issue(t, "Issuing CA", true, root, rootKey)
+	leaf, _ := issue(t, "leaf.example.com", false, intermediate, intermediateKey)
+
+	otherRoot, otherRootKey := issue(t, "Other Root", true, nil, nil)
+	otherIntermediate, otherIntermediateKey := issue(t, "Other CA", true, otherRoot, otherRootKey)
+	otherLeaf, _ := issue(t, "other.example.net", false, otherIntermediate, otherIntermediateKey)
+
+	report := AnalyzeChain([]*x509.Certificate{leaf, intermediate, otherIntermediate, otherLeaf})
+
+	unrelated := map[string]bool{}
+	for _, finding := range report.Findings {
+		if finding.Problem == ProblemUnrelated {
+			unrelated[finding.Subject] = true
+		}
+	}
+	for _, want := range []string{"Other CA", "other.example.net"} {
+		if !unrelated[want] {
+			t.Errorf("%q should be reported as unrelated; findings: %v", want, problemNames(report))
+		}
+	}
+	if unrelated["leaf.example.com"] || unrelated["Issuing CA"] {
+		t.Error("the primary chain must not be reported as unrelated")
+	}
+}


### PR DESCRIPTION
> Stacked on #59 → #54. This PR's own diff is the chain analysis.

## The gap

Verifying a chain and *serving it correctly* are different questions, and nothing reports the second one. A server can present a chain your browser accepts and `curl` refuses — browsers chase the AIA URL to fetch a missing intermediate; curl, Go and Java do not. It is the classic **"works in Chrome, breaks in curl"** bug.

openssl explicitly declines to help. Its own docs: `s_client -showcerts` "displays the server certificate list as sent by the server … **it is not a verified chain**."

This is the one proposal in the audit that **no competitor ships**. certigo has an [open issue](https://github.com/square/certigo/issues/132) asking for it.

## What it reports

`AnalyzeChain` takes the certificates *in the order they were presented* and reports:

- **missing issuer** — with the AIA CA-Issuers URL that would supply it
- **redundant root** — a root the server should not be sending (clients ignore it; it just costs bytes every handshake)
- **out of order** — not leaf-first, which RFC 8446 asks for
- **duplicate** — the same certificate sent twice
- **unrelated** — a certificate belonging to no chain in the bundle

## The design decision worth reviewing

**The check is purely structural. It never asks a verifier whether the chain builds.**

That is not fastidiousness — I tried the verifier-based approach first and it was *actively broken*. On macOS, Go's verification delegates to the platform verifier, which **chases the AIA URL and fetches the missing intermediate over the network**. So the exact bug this is meant to catch verifies perfectly clean.

Here is the live proof, and it is also the best demo of the feature:

```text
$ y509 validate incomplete-chain.badssl.com:443
✅ Certificate chain is valid.          <-- macOS fetched the missing intermediate
Trust anchor: ISRG Root X1

Chain as presented:
  • missing issuer: *.badssl.com
    the chain stops at a certificate that is not a CA; its issuer "R13" was never
    sent, so a client that does not chase AIA (curl, Go, Java) cannot build a chain
    fetch from: http://r13.i.lencr.org/
```

The chain **verified** and is still misconfigured. A verifier-based check would have been quietly useless on the platform most people run it from. Asking "what did you actually send me" cannot be fooled.

## Avoiding the false positive

The rule separating a real missing intermediate from a **cross-signed root** is: *a chain must terminate at a CA.*

`GTS Root R1` — which google.com sends — has an absent issuer (GlobalSign Root CA) and must **not** be flagged, because the client trusts the root itself. A leaf whose intermediate was never sent **must** be. My first attempt flagged google.com; this one doesn't. Both cases are pinned by tests.

## Verified against real servers

```text
google.com:443                    clean
github.com:443                    clean
cloudflare.com:443                clean
incomplete-chain.badssl.com:443   missing issuer (correct)
```

Tests are offline and synthetic — well-formed, missing intermediate, cross-signed root, redundant root, out of order, duplicate, unrelated, lone self-signed, empty — so they cannot be swayed by the platform verifier either.

`make lint` clean, `markdownlint` clean, full suite green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added certificate-chain presentation analysis to the validation command.
  - Reports missing issuers, redundant roots, out-of-order certificates, duplicates, and unrelated certificates.
  - Clearly distinguishes successful certificate verification from correctly configured chain serving.
  - Includes relevant issuer-fetch details when an intermediate certificate is missing.

- **Documentation**
  - Added usage guidance and an example explaining chain presentation findings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->