### PR TITLE
fix(release): let a partially-failed release be re-run

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -30,6 +30,10 @@ archives:
 # 自動的にシェル補完スクリプトを生成
 release:
   prerelease: auto
+  # Lets a partially-failed release be re-run. Without this, re-uploading an
+  # asset that is already on the release fails with a 422 and goreleaser aborts
+  # before it gets to the Homebrew step.
+  replace_existing_artifacts: true
 
 checksum:
   name_template: "{{ .ProjectName }}-{{ .Version }}-checksums.txt"


### PR DESCRIPTION
Same fix as kanywst/spiffe-compliance-checker#17.

When a release fails partway through — an expired Homebrew tap token, a network blip — re-running it fails earlier still: goreleaser re-uploads every archive, GitHub rejects each with a `422 already_exists`, and the run aborts at `scm releases` before reaching the formula. Recovery means deleting the assets by hand.

`replace_existing_artifacts` makes goreleaser delete the conflicting asset and retry the upload on that 422, so a rerun resumes from wherever the previous attempt died. `goreleaser check` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release processing so later publishing steps can continue when earlier artifact uploads are partially unsuccessful.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->