### PR TITLE
test: raise coverage to 82% and gate it in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,9 @@ jobs:
     - name: Run tests
       run: make test-json > test-report.json
 
+    - name: Coverage threshold
+      run: make test-coverage
+
     - name: Annotate tests
       if: always()
       uses: guyarb/golang-test-annotations@v0.9.0

--- a/Makefile
+++ b/Makefile
@@ -51,16 +51,27 @@ COVERAGE_THRESHOLD ?= 80.0
 .PHONY: test-coverage
 test-coverage: demo-certs
 	go test -coverprofile=coverage.out -covermode=atomic ./...
-	@go tool cover -func=coverage.out | tail -1
-	@go tool cover -func=coverage.out | awk -v min=$(COVERAGE_THRESHOLD) '\
-		/^total:/ { \
-			total = $$3; sub(/%$$/, "", total); \
-			if (total + 0 < min + 0) { \
-				printf "coverage %.1f%% is below the %.1f%% threshold\n", total, min; \
-				exit 1 \
-			} \
-			printf "coverage %.1f%% meets the %.1f%% threshold\n", total, min \
-		}'
+	@$(MAKE) --no-print-directory check-coverage
+
+# Split out so the gate can be re-run against an existing profile, and so every
+# way of not knowing the coverage is an error. A gate that fails open is worse
+# than no gate: it reads as protection while providing none.
+.PHONY: check-coverage
+check-coverage:
+	@case '$(COVERAGE_THRESHOLD)' in \
+		''|*[!0-9.]*|*.*.*) \
+			echo "COVERAGE_THRESHOLD must be a number, got '$(COVERAGE_THRESHOLD)'" >&2; exit 1 ;; \
+	esac; \
+	summary=$$(go tool cover -func=coverage.out) || { \
+		echo "go tool cover failed to read coverage.out" >&2; exit 1; }; \
+	total=$$(printf '%s\n' "$$summary" | awk '/^total:/ { sub(/%$$/, "", $$3); print $$3 }'); \
+	if [ -z "$$total" ]; then \
+		echo "no total line in the coverage summary" >&2; exit 1; \
+	fi; \
+	if awk -v total="$$total" -v min='$(COVERAGE_THRESHOLD)' 'BEGIN { exit !(total + 0 < min + 0) }'; then \
+		echo "coverage $$total% is below the $(COVERAGE_THRESHOLD)% threshold" >&2; exit 1; \
+	fi; \
+	echo "coverage $$total% meets the $(COVERAGE_THRESHOLD)% threshold"
 
 # Clean build artifacts
 .PHONY: clean

--- a/Makefile
+++ b/Makefile
@@ -44,10 +44,23 @@ test: demo-certs
 test-json: demo-certs
 	@go test -v -json $(GOTEST_ARGS) ./...
 
-# Run tests with coverage
+# Run tests with coverage and fail if it slips below the threshold. Without a
+# gate the number only ever drifts down, one untested branch at a time.
+COVERAGE_THRESHOLD ?= 80.0
+
 .PHONY: test-coverage
 test-coverage: demo-certs
-	go test -cover ./...
+	go test -coverprofile=coverage.out -covermode=atomic ./...
+	@go tool cover -func=coverage.out | tail -1
+	@go tool cover -func=coverage.out | awk -v min=$(COVERAGE_THRESHOLD) '\
+		/^total:/ { \
+			total = $$3; sub(/%$$/, "", total); \
+			if (total + 0 < min + 0) { \
+				printf "coverage %.1f%% is below the %.1f%% threshold\n", total, min; \
+				exit 1 \
+			} \
+			printf "coverage %.1f%% meets the %.1f%% threshold\n", total, min \
+		}'
 
 # Clean build artifacts
 .PHONY: clean

--- a/Makefile
+++ b/Makefile
@@ -59,9 +59,13 @@ test-coverage: demo-certs
 .PHONY: check-coverage
 check-coverage:
 	@case '$(COVERAGE_THRESHOLD)' in \
-		''|*[!0-9.]*|*.*.*) \
-			echo "COVERAGE_THRESHOLD must be a number, got '$(COVERAGE_THRESHOLD)'" >&2; exit 1 ;; \
+		''|*[!0-9.]*|*.*.*) bad=1 ;; \
+		*[0-9]*) bad= ;; \
+		*) bad=1 ;; \
 	esac; \
+	if [ -n "$$bad" ]; then \
+		echo "COVERAGE_THRESHOLD must be a number, got '$(COVERAGE_THRESHOLD)'" >&2; exit 1; \
+	fi; \
 	summary=$$(go tool cover -func=coverage.out) || { \
 		echo "go tool cover failed to read coverage.out" >&2; exit 1; }; \
 	total=$$(printf '%s\n' "$$summary" | awk '/^total:/ { sub(/%$$/, "", $$3); print $$3 }'); \

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	charm.land/huh/v2 v2.0.3
 	charm.land/lipgloss/v2 v2.0.5
 	github.com/spf13/cobra v1.10.2
+	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.21.0
 	go.uber.org/zap v1.28.0
 )
@@ -189,7 +190,6 @@ require (
 	github.com/sourcegraph/go-diff v0.8.0 // indirect
 	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect
-	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/ssgreg/nlreturn/v2 v2.2.1 // indirect
 	github.com/stbenjam/no-sprintf-host-port v0.3.1 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect

--- a/internal/cmd/chain_test.go
+++ b/internal/cmd/chain_test.go
@@ -1,0 +1,106 @@
+package cmd
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// testChain is a two-certificate chain generated per test run. Committing
+// fixtures would mean fixtures that expire, and validate's whole job is to
+// notice expiry.
+type testChain struct {
+	// LeafPEM is the leaf on its own.
+	LeafPEM []byte
+	// ChainPEM is leaf then CA, the order a server should present.
+	ChainPEM []byte
+	// CAPEM is the root, usable as a --roots file.
+	CAPEM []byte
+	// Leaf and CA are the parsed forms, for building a tls.Certificate.
+	Leaf, CA *x509.Certificate
+	// LeafKey signs for the leaf.
+	LeafKey *ecdsa.PrivateKey
+}
+
+func newTestChain(t *testing.T, dnsNames ...string) *testChain {
+	t.Helper()
+
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generating the CA key: %v", err)
+	}
+	caTmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "y509 test CA"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTmpl, caTmpl, &caKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("signing the CA: %v", err)
+	}
+	ca, err := x509.ParseCertificate(caDER)
+	if err != nil {
+		t.Fatalf("parsing the CA: %v", err)
+	}
+
+	leafKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generating the leaf key: %v", err)
+	}
+	leafTmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "y509 test leaf"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		DNSNames:     dnsNames,
+	}
+	leafDER, err := x509.CreateCertificate(rand.Reader, leafTmpl, ca, &leafKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("signing the leaf: %v", err)
+	}
+	leaf, err := x509.ParseCertificate(leafDER)
+	if err != nil {
+		t.Fatalf("parsing the leaf: %v", err)
+	}
+
+	encode := func(ders ...[]byte) []byte {
+		var out []byte
+		for _, der := range ders {
+			out = append(out, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})...)
+		}
+		return out
+	}
+
+	return &testChain{
+		LeafPEM:  encode(leafDER),
+		ChainPEM: encode(leafDER, caDER),
+		CAPEM:    encode(caDER),
+		Leaf:     leaf,
+		CA:       ca,
+		LeafKey:  leafKey,
+	}
+}
+
+// write puts the given PEM in a fresh temp file and returns its path.
+func write(t *testing.T, name string, data []byte) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("writing %s: %v", name, err)
+	}
+	return path
+}

--- a/internal/cmd/flags_test.go
+++ b/internal/cmd/flags_test.go
@@ -1,0 +1,194 @@
+package cmd
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+// newValidateFlags builds a command carrying the same flag set validate has, so
+// verifyOptionsFromFlags can be exercised without going through cobra dispatch.
+func newValidateFlags(t *testing.T) *cobra.Command {
+	t.Helper()
+	cmd := &cobra.Command{}
+	cmd.Flags().String("roots", "", "")
+	cmd.Flags().Bool("no-system-roots", false, "")
+	cmd.Flags().String("host", "", "")
+	return cmd
+}
+
+func set(t *testing.T, cmd *cobra.Command, name, value string) {
+	t.Helper()
+	if err := cmd.Flags().Set(name, value); err != nil {
+		t.Fatalf("setting --%s: %v", name, err)
+	}
+}
+
+func TestVerifyOptionsFromFlagsDefaults(t *testing.T) {
+	opts, err := verifyOptionsFromFlags(newValidateFlags(t))
+	if err != nil {
+		t.Fatalf("verifyOptionsFromFlags() error = %v", err)
+	}
+
+	if opts.SkipSystemRoots {
+		t.Error("SkipSystemRoots is set without --no-system-roots")
+	}
+	if opts.DNSName != "" {
+		t.Errorf("DNSName = %q, want empty so validate can fall back to the connected host", opts.DNSName)
+	}
+	if len(opts.ExtraRoots) != 0 {
+		t.Errorf("ExtraRoots has %d entries, want none", len(opts.ExtraRoots))
+	}
+}
+
+func TestVerifyOptionsFromFlagsHost(t *testing.T) {
+	cmd := newValidateFlags(t)
+	set(t, cmd, "host", "example.com")
+
+	opts, err := verifyOptionsFromFlags(cmd)
+	if err != nil {
+		t.Fatalf("verifyOptionsFromFlags() error = %v", err)
+	}
+	if opts.DNSName != "example.com" {
+		t.Errorf("DNSName = %q, want %q", opts.DNSName, "example.com")
+	}
+}
+
+func TestVerifyOptionsFromFlagsLoadsRoots(t *testing.T) {
+	chain := newTestChain(t)
+	rootsPath := write(t, "roots.pem", chain.CAPEM)
+
+	cmd := newValidateFlags(t)
+	set(t, cmd, "roots", rootsPath)
+
+	opts, err := verifyOptionsFromFlags(cmd)
+	if err != nil {
+		t.Fatalf("verifyOptionsFromFlags() error = %v", err)
+	}
+	if len(opts.ExtraRoots) != 1 {
+		t.Fatalf("ExtraRoots has %d entries, want 1", len(opts.ExtraRoots))
+	}
+	if got := opts.ExtraRoots[0].Subject.CommonName; got != chain.CA.Subject.CommonName {
+		t.Errorf("loaded anchor CN = %q, want %q", got, chain.CA.Subject.CommonName)
+	}
+}
+
+func TestVerifyOptionsFromFlagsMissingRootsFileNamesThePath(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "absent.pem")
+
+	cmd := newValidateFlags(t)
+	set(t, cmd, "roots", missing)
+
+	_, err := verifyOptionsFromFlags(cmd)
+	if err == nil {
+		t.Fatal("verifyOptionsFromFlags() error = nil for an unreadable --roots file")
+	}
+	// The path is the one piece of information the user needs to fix it.
+	if !strings.Contains(err.Error(), missing) {
+		t.Errorf("error = %q, want it to name %q", err, missing)
+	}
+}
+
+func TestVerifyOptionsFromFlagsRejectsNoSystemRootsAlone(t *testing.T) {
+	cmd := newValidateFlags(t)
+	set(t, cmd, "no-system-roots", "true")
+
+	_, err := verifyOptionsFromFlags(cmd)
+	if err == nil {
+		t.Fatal("verifyOptionsFromFlags() error = nil; --no-system-roots alone leaves nothing to trust")
+	}
+	if !strings.Contains(err.Error(), "--roots") {
+		t.Errorf("error = %q, want it to point at --roots", err)
+	}
+}
+
+func TestVerifyOptionsFromFlagsNoSystemRootsWithRoots(t *testing.T) {
+	chain := newTestChain(t)
+	cmd := newValidateFlags(t)
+	set(t, cmd, "no-system-roots", "true")
+	set(t, cmd, "roots", write(t, "roots.pem", chain.CAPEM))
+
+	opts, err := verifyOptionsFromFlags(cmd)
+	if err != nil {
+		t.Fatalf("verifyOptionsFromFlags() error = %v", err)
+	}
+	if !opts.SkipSystemRoots || len(opts.ExtraRoots) != 1 {
+		t.Errorf("got SkipSystemRoots=%v ExtraRoots=%d, want true and 1",
+			opts.SkipSystemRoots, len(opts.ExtraRoots))
+	}
+}
+
+// newInputFlags mirrors the persistent flags loadInput reads off the root.
+func newInputFlags(t *testing.T) *cobra.Command {
+	t.Helper()
+	cmd := &cobra.Command{}
+	cmd.Flags().String("connect", "", "")
+	cmd.Flags().String("input", "", "")
+	cmd.Flags().String("servername", "", "")
+	cmd.Flags().String("starttls", "", "")
+	cmd.Flags().Duration("timeout", 5*time.Second, "")
+	// cobra attaches a context during Execute; a hand-built command has none,
+	// and connectFromFlags passes it straight to context.WithTimeout.
+	cmd.SetContext(context.Background())
+	return cmd
+}
+
+func TestLoadInputFromPositionalFile(t *testing.T) {
+	chain := newTestChain(t)
+	path := write(t, "chain.pem", chain.ChainPEM)
+
+	got, err := loadInput(newInputFlags(t), []string{path})
+	if err != nil {
+		t.Fatalf("loadInput() error = %v", err)
+	}
+	if len(got.Certs) != 2 {
+		t.Errorf("loaded %d certificates, want 2", len(got.Certs))
+	}
+	if got.Host != "" {
+		t.Errorf("Host = %q, want empty for a file source", got.Host)
+	}
+}
+
+func TestLoadInputFallsBackToInputFlag(t *testing.T) {
+	chain := newTestChain(t)
+	cmd := newInputFlags(t)
+	set(t, cmd, "input", write(t, "leaf.pem", chain.LeafPEM))
+
+	got, err := loadInput(cmd, nil)
+	if err != nil {
+		t.Fatalf("loadInput() error = %v", err)
+	}
+	if len(got.Certs) != 1 {
+		t.Errorf("loaded %d certificates, want 1", len(got.Certs))
+	}
+}
+
+func TestLoadInputPositionalWinsOverInputFlag(t *testing.T) {
+	chain := newTestChain(t)
+	cmd := newInputFlags(t)
+	set(t, cmd, "input", write(t, "leaf.pem", chain.LeafPEM))
+
+	// The argument names two certificates, the flag one, so the count says which
+	// source was used.
+	got, err := loadInput(cmd, []string{write(t, "chain.pem", chain.ChainPEM)})
+	if err != nil {
+		t.Fatalf("loadInput() error = %v", err)
+	}
+	if len(got.Certs) != 2 {
+		t.Errorf("loaded %d certificates, want the positional argument's 2", len(got.Certs))
+	}
+}
+
+func TestLoadInputMissingFileIsAnError(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "nope.pem")
+
+	// A path-shaped target must stay a file lookup rather than being dialled,
+	// otherwise a typo comes back as a DNS error.
+	if _, err := loadInput(newInputFlags(t), []string{missing}); err == nil {
+		t.Fatal("loadInput() error = nil for a missing file")
+	}
+}

--- a/internal/cmd/run_test.go
+++ b/internal/cmd/run_test.go
@@ -1,0 +1,340 @@
+package cmd
+
+import (
+	"bytes"
+	"crypto/tls"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/pflag"
+)
+
+// RootCmd is a package-level singleton, and cobra has no way to reset one. Each
+// run therefore snapshots every flag value and restores it afterwards, or a
+// --roots left over from one test would silently change the next.
+func restoreFlags(t *testing.T) {
+	t.Helper()
+
+	type saved struct {
+		flag    *pflag.Flag
+		value   string
+		changed bool
+	}
+	var all []saved
+
+	record := func(f *pflag.Flag) {
+		all = append(all, saved{flag: f, value: f.Value.String(), changed: f.Changed})
+	}
+	RootCmd.PersistentFlags().VisitAll(record)
+	RootCmd.Flags().VisitAll(record)
+	for _, sub := range RootCmd.Commands() {
+		sub.Flags().VisitAll(record)
+	}
+
+	t.Cleanup(func() {
+		for _, s := range all {
+			_ = s.flag.Value.Set(s.value)
+			s.flag.Changed = s.changed
+		}
+		RootCmd.SetArgs(nil)
+	})
+}
+
+// runRoot dispatches through the real root command and returns whatever the
+// subcommand printed to stdout. The subcommands print with fmt.Println rather
+// than through cobra's writer, so stdout itself has to be swapped.
+func runRoot(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	restoreFlags(t)
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	oldStdout := os.Stdout
+	os.Stdout = w
+
+	var cobraOut bytes.Buffer
+	RootCmd.SetOut(&cobraOut)
+	RootCmd.SetErr(&cobraOut)
+	RootCmd.SetArgs(args)
+
+	runErr := RootCmd.Execute()
+
+	os.Stdout = oldStdout
+	if closeErr := w.Close(); closeErr != nil {
+		t.Fatalf("closing the pipe: %v", closeErr)
+	}
+	out, readErr := io.ReadAll(r)
+	if readErr != nil {
+		t.Fatalf("reading captured stdout: %v", readErr)
+	}
+
+	return string(out) + cobraOut.String(), runErr
+}
+
+func TestValidateRejectsAChainWithNoTrustedAnchor(t *testing.T) {
+	chain := newTestChain(t)
+	path := write(t, "chain.pem", chain.ChainPEM)
+
+	out, err := runRoot(t, "validate", path)
+	if err == nil {
+		t.Fatal("validate exited 0 for a chain anchored at an untrusted root")
+	}
+	// The distinction matters: the chain links up fine, it just does not reach a
+	// root the system trusts, and validate must not pass that in CI.
+	if !strings.Contains(err.Error(), "chain is") {
+		t.Errorf("error = %q, want it to report the trust level", err)
+	}
+	if out == "" {
+		t.Error("validate printed nothing; the report is the point of the command")
+	}
+}
+
+func TestValidateAcceptsTheChainWithItsOwnRoot(t *testing.T) {
+	chain := newTestChain(t)
+	dir := t.TempDir()
+	chainPath := filepath.Join(dir, "chain.pem")
+	rootsPath := filepath.Join(dir, "roots.pem")
+	if err := os.WriteFile(chainPath, chain.ChainPEM, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(rootsPath, chain.CAPEM, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := runRoot(t, "validate", chainPath, "--roots", rootsPath, "--no-system-roots")
+	if err != nil {
+		t.Fatalf("validate failed with its own CA supplied as an anchor: %v\n%s", err, out)
+	}
+}
+
+func TestValidateReportsAMissingFile(t *testing.T) {
+	_, err := runRoot(t, "validate", filepath.Join(t.TempDir(), "absent.pem"))
+	if err == nil {
+		t.Fatal("validate exited 0 for a missing file")
+	}
+}
+
+func TestExportWritesRequestedFormats(t *testing.T) {
+	chain := newTestChain(t)
+	src := write(t, "chain.pem", chain.ChainPEM)
+
+	for _, format := range []string{"pem", "der", "crt", "cert"} {
+		t.Run(format, func(t *testing.T) {
+			out := filepath.Join(t.TempDir(), "cert."+format)
+
+			if _, err := runRoot(t, "export", "0", format, out, "-i", src); err != nil {
+				t.Fatalf("export failed: %v", err)
+			}
+
+			data, err := os.ReadFile(out)
+			if err != nil {
+				t.Fatalf("reading the exported file: %v", err)
+			}
+			if len(data) == 0 {
+				t.Fatal("exported file is empty")
+			}
+			// der is the only format written as raw bytes.
+			isPEM := bytes.HasPrefix(data, []byte("-----BEGIN CERTIFICATE-----"))
+			if format == "der" && isPEM {
+				t.Error("der output is PEM-encoded")
+			}
+			if format != "der" && !isPEM {
+				t.Errorf("%s output is not PEM-encoded", format)
+			}
+		})
+	}
+}
+
+func TestExportCreatesMissingDirectories(t *testing.T) {
+	chain := newTestChain(t)
+	src := write(t, "chain.pem", chain.ChainPEM)
+	out := filepath.Join(t.TempDir(), "nested", "deeper", "cert.pem")
+
+	if _, err := runRoot(t, "export", "0", "pem", out, "-i", src); err != nil {
+		t.Fatalf("export failed: %v", err)
+	}
+	if _, err := os.Stat(out); err != nil {
+		t.Errorf("expected %s to exist: %v", out, err)
+	}
+}
+
+func TestExportRejectsBadIndexes(t *testing.T) {
+	chain := newTestChain(t)
+	src := write(t, "chain.pem", chain.ChainPEM)
+
+	tests := []struct {
+		name string
+		// args are given in full because a negative index has to come after a
+		// "--" separator, or pflag reads it as a shorthand flag.
+		args func(out string) []string
+		want string
+	}{
+		{
+			name: "not a number",
+			args: func(out string) []string { return []string{"export", "abc", "pem", out, "-i", src} },
+			want: "invalid certificate index",
+		},
+		{
+			name: "past the end",
+			args: func(out string) []string { return []string{"export", "9", "pem", out, "-i", src} },
+			want: "out of range",
+		},
+		{
+			name: "negative",
+			args: func(out string) []string { return []string{"export", "-i", src, "--", "-1", "pem", out} },
+			want: "out of range",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := filepath.Join(t.TempDir(), "cert.pem")
+
+			_, err := runRoot(t, tt.args(out)...)
+			if err == nil {
+				t.Fatal("export accepted a bad index")
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Errorf("error = %q, want it to mention %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestVersionSubcommandPrintsAVersion(t *testing.T) {
+	out, err := runRoot(t, "version")
+	if err != nil {
+		t.Fatalf("version failed: %v", err)
+	}
+	if !strings.Contains(out, "y509") {
+		t.Errorf("version output = %q, want it to name the program", out)
+	}
+}
+
+func TestCompletionSubcommandEmitsAScript(t *testing.T) {
+	for _, shell := range []string{"bash", "zsh", "fish", "powershell"} {
+		t.Run(shell, func(t *testing.T) {
+			out, err := runRoot(t, "completion", shell)
+			if err != nil {
+				t.Fatalf("completion %s failed: %v", shell, err)
+			}
+			if len(out) == 0 {
+				t.Errorf("completion %s produced no script", shell)
+			}
+		})
+	}
+}
+
+// startTLSServer serves the test chain on 127.0.0.1 and returns host:port. It
+// keeps the connect path hermetic: no DNS, no outbound traffic.
+func startTLSServer(t *testing.T, chain *testChain) string {
+	t.Helper()
+
+	cert := tls.Certificate{
+		Certificate: [][]byte{chain.Leaf.Raw, chain.CA.Raw},
+		PrivateKey:  chain.LeafKey,
+	}
+	ln, err := tls.Listen("tcp", "127.0.0.1:0", &tls.Config{Certificates: []tls.Certificate{cert}})
+	if err != nil {
+		t.Fatalf("listening: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			// The handshake is all y509 needs; reading once drives it to
+			// completion, then the connection can go.
+			go func() {
+				defer func() { _ = conn.Close() }()
+				_ = conn.(*tls.Conn).Handshake()
+			}()
+		}
+	}()
+
+	return ln.Addr().String()
+}
+
+func TestLoadInputFetchesFromAServer(t *testing.T) {
+	chain := newTestChain(t, "localhost")
+	addr := startTLSServer(t, chain)
+
+	cmd := newInputFlags(t)
+	set(t, cmd, "connect", addr)
+
+	got, err := loadInput(cmd, nil)
+	if err != nil {
+		t.Fatalf("loadInput() error = %v", err)
+	}
+	if len(got.Certs) != 2 {
+		t.Errorf("fetched %d certificates, want the 2 the server presented", len(got.Certs))
+	}
+	host, _, splitErr := net.SplitHostPort(addr)
+	if splitErr != nil {
+		t.Fatal(splitErr)
+	}
+	if got.Host != host {
+		t.Errorf("Host = %q, want %q so validate can check the leaf against it", got.Host, host)
+	}
+}
+
+func TestLoadInputTreatsAHostPortArgumentAsAServer(t *testing.T) {
+	chain := newTestChain(t, "localhost")
+	addr := startTLSServer(t, chain)
+
+	// No --connect: the colon alone should be enough to read this as an address.
+	got, err := loadInput(newInputFlags(t), []string{addr})
+	if err != nil {
+		t.Fatalf("loadInput() error = %v", err)
+	}
+	if len(got.Certs) != 2 {
+		t.Errorf("fetched %d certificates, want 2", len(got.Certs))
+	}
+}
+
+func TestLoadInputRejectsAnUnknownStartTLSProtocol(t *testing.T) {
+	cmd := newInputFlags(t)
+	set(t, cmd, "connect", "127.0.0.1:1")
+	set(t, cmd, "starttls", "gopher")
+
+	_, err := loadInput(cmd, nil)
+	if err == nil {
+		t.Fatal("loadInput() error = nil for an unsupported --starttls protocol")
+	}
+	// Rejecting before dialling is the point: otherwise the typo surfaces as a
+	// connection error instead.
+	if !strings.Contains(err.Error(), "starttls") {
+		t.Errorf("error = %q, want it to name the flag", err)
+	}
+}
+
+func TestExecuteSetsUpVersionAndSilencing(t *testing.T) {
+	restoreFlags(t)
+	oldVersion, oldSilenceErr, oldSilenceUsage := RootCmd.Version, RootCmd.SilenceErrors, RootCmd.SilenceUsage
+	t.Cleanup(func() {
+		RootCmd.Version, RootCmd.SilenceErrors, RootCmd.SilenceUsage = oldVersion, oldSilenceErr, oldSilenceUsage
+	})
+
+	var out bytes.Buffer
+	RootCmd.SetOut(&out)
+	RootCmd.SetErr(&out)
+	// A subcommand that cannot fail, so Execute does not reach its os.Exit(1).
+	RootCmd.SetArgs([]string{"version"})
+
+	Execute()
+
+	if RootCmd.Version == "" {
+		t.Error("Execute did not set Version, so cobra would not register --version")
+	}
+	if !RootCmd.SilenceErrors || !RootCmd.SilenceUsage {
+		t.Error("Execute did not silence cobra's own error and usage printing")
+	}
+}

--- a/internal/cmd/run_test.go
+++ b/internal/cmd/run_test.go
@@ -232,6 +232,11 @@ func TestCompletionSubcommandEmitsAScript(t *testing.T) {
 
 // startTLSServer serves the test chain on 127.0.0.1 and returns host:port. It
 // keeps the connect path hermetic: no DNS, no outbound traffic.
+//
+// The server deliberately presents leaf and root. A correctly configured server
+// would omit the root, but shipping it is a common misconfiguration and one of
+// the things y509 exists to show, so the fetch path should be exercised against
+// a chain that has it rather than only against a tidy one.
 func startTLSServer(t *testing.T, chain *testChain) string {
 	t.Helper()
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,140 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// LoadConfig searches $HOME and the working directory for .y509.yaml. Both are
+// redirected so a developer's real config cannot change the result.
+func isolate(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home) // os.UserHomeDir on Windows
+	t.Chdir(t.TempDir())
+	return home
+}
+
+func writeConfig(t *testing.T, dir, body string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, ".y509.yaml"), []byte(body), 0o600); err != nil {
+		t.Fatalf("writing config: %v", err)
+	}
+}
+
+func TestLoadConfigDefaults(t *testing.T) {
+	isolate(t)
+
+	cfg, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("LoadConfig() error = %v", err)
+	}
+
+	if cfg.ExpiryWarningDays != DefaultExpiryWarningDays {
+		t.Errorf("ExpiryWarningDays = %d, want %d", cfg.ExpiryWarningDays, DefaultExpiryWarningDays)
+	}
+	want := newDefaultTheme()
+	if cfg.Theme != want {
+		t.Errorf("Theme = %+v, want %+v", cfg.Theme, want)
+	}
+}
+
+func TestLoadConfigMissingFileIsNotAnError(t *testing.T) {
+	isolate(t)
+
+	// No .y509.yaml anywhere: a ConfigFileNotFoundError must be swallowed so the
+	// TUI still starts with defaults.
+	if _, err := LoadConfig(); err != nil {
+		t.Errorf("LoadConfig() error = %v, want nil when no config file exists", err)
+	}
+}
+
+func TestLoadConfigReadsHomeConfig(t *testing.T) {
+	home := isolate(t)
+	writeConfig(t, home, "theme:\n  text: \"#ffffff\"\n  title: \"#ff0000\"\nexpiry_warning_days: 7\n")
+
+	cfg, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("LoadConfig() error = %v", err)
+	}
+
+	if cfg.Theme.Text != "#ffffff" {
+		t.Errorf("Theme.Text = %q, want %q", cfg.Theme.Text, "#ffffff")
+	}
+	if cfg.Theme.Title != "#ff0000" {
+		t.Errorf("Theme.Title = %q, want %q", cfg.Theme.Title, "#ff0000")
+	}
+	if cfg.ExpiryWarningDays != 7 {
+		t.Errorf("ExpiryWarningDays = %d, want 7", cfg.ExpiryWarningDays)
+	}
+	// Keys the file did not mention keep their defaults.
+	if want := newDefaultTheme().Border; cfg.Theme.Border != want {
+		t.Errorf("Theme.Border = %q, want the default %q", cfg.Theme.Border, want)
+	}
+}
+
+func TestLoadConfigPrefersWorkingDirectoryOverHome(t *testing.T) {
+	home := isolate(t)
+	writeConfig(t, home, "theme:\n  text: \"#111111\"\n")
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	writeConfig(t, cwd, "theme:\n  text: \"#222222\"\n")
+
+	cfg, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("LoadConfig() error = %v", err)
+	}
+
+	// $HOME is registered first, so viper resolves it ahead of ".".
+	if cfg.Theme.Text != "#111111" {
+		t.Errorf("Theme.Text = %q, want the home config to win with %q", cfg.Theme.Text, "#111111")
+	}
+}
+
+func TestLoadConfigClampsNonPositiveExpiryWindow(t *testing.T) {
+	for _, body := range []string{"expiry_warning_days: 0\n", "expiry_warning_days: -5\n"} {
+		t.Run(body, func(t *testing.T) {
+			home := isolate(t)
+			writeConfig(t, home, body)
+
+			cfg, err := LoadConfig()
+			if err != nil {
+				t.Fatalf("LoadConfig() error = %v", err)
+			}
+			if cfg.ExpiryWarningDays != DefaultExpiryWarningDays {
+				t.Errorf("ExpiryWarningDays = %d, want it clamped to %d",
+					cfg.ExpiryWarningDays, DefaultExpiryWarningDays)
+			}
+		})
+	}
+}
+
+func TestLoadConfigReportsMalformedFileButStillReturnsDefaults(t *testing.T) {
+	home := isolate(t)
+	writeConfig(t, home, "theme: [this is not a mapping\n")
+
+	cfg, err := LoadConfig()
+	if err == nil {
+		t.Error("LoadConfig() error = nil, want a parse error for malformed YAML")
+	}
+	if cfg == nil {
+		t.Fatal("LoadConfig() returned a nil config; callers rely on it always being usable")
+	}
+	if cfg.ExpiryWarningDays != DefaultExpiryWarningDays {
+		t.Errorf("ExpiryWarningDays = %d, want the default %d even after a parse error",
+			cfg.ExpiryWarningDays, DefaultExpiryWarningDays)
+	}
+}
+
+func TestNewDefaultThemeHasNoEmptyColors(t *testing.T) {
+	theme := newDefaultTheme()
+
+	if theme.Text == "" || theme.Border == "" || theme.Background == "" {
+		t.Errorf("default theme has empty core colors: %+v", theme)
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -75,7 +75,7 @@ func TestLoadConfigReadsHomeConfig(t *testing.T) {
 	}
 }
 
-func TestLoadConfigPrefersWorkingDirectoryOverHome(t *testing.T) {
+func TestLoadConfigPrefersHomeOverWorkingDirectory(t *testing.T) {
 	home := isolate(t)
 	writeConfig(t, home, "theme:\n  text: \"#111111\"\n")
 

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -1,0 +1,104 @@
+package logger
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+func restoreLog(t *testing.T) {
+	t.Helper()
+	old := Log
+	t.Cleanup(func() { Log = old })
+}
+
+func TestInitWritesToTheGivenFile(t *testing.T) {
+	restoreLog(t)
+	logFile := filepath.Join(t.TempDir(), "y509.log")
+
+	if err := Init(logFile, false); err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+
+	Log.Info("hello from the test")
+	if err := Log.Sync(); err != nil {
+		t.Fatalf("Sync() error = %v", err)
+	}
+
+	data, err := os.ReadFile(logFile)
+	if err != nil {
+		t.Fatalf("reading log file: %v", err)
+	}
+	if !strings.Contains(string(data), "hello from the test") {
+		t.Errorf("log file does not contain the message, got %q", data)
+	}
+}
+
+func TestInitDebugEnablesDebugLevel(t *testing.T) {
+	restoreLog(t)
+	logFile := filepath.Join(t.TempDir(), "debug.log")
+
+	if err := Init(logFile, true); err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+	if !Log.Core().Enabled(zap.DebugLevel) {
+		t.Error("debug level is not enabled after Init(_, true)")
+	}
+
+	Log.Debug("a debug line")
+	_ = Log.Sync()
+
+	data, err := os.ReadFile(logFile)
+	if err != nil {
+		t.Fatalf("reading log file: %v", err)
+	}
+	if !strings.Contains(string(data), "a debug line") {
+		t.Errorf("debug line was not written, got %q", data)
+	}
+}
+
+func TestInitWithoutDebugDropsDebugLines(t *testing.T) {
+	restoreLog(t)
+	logFile := filepath.Join(t.TempDir(), "info.log")
+
+	if err := Init(logFile, false); err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+	if Log.Core().Enabled(zap.DebugLevel) {
+		t.Error("debug level should be disabled by default")
+	}
+}
+
+func TestInitDefaultsToTempDir(t *testing.T) {
+	restoreLog(t)
+	// The default path is shared with any other y509 on the machine, so point
+	// TMPDIR somewhere private for the duration of the test.
+	tmp := t.TempDir()
+	t.Setenv("TMPDIR", tmp)
+
+	if err := Init("", false); err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+	Log.Info("default path")
+	_ = Log.Sync()
+
+	if _, err := os.Stat(filepath.Join(os.TempDir(), "y509.log")); err != nil {
+		t.Errorf("expected y509.log in %s: %v", os.TempDir(), err)
+	}
+}
+
+func TestInitReturnsErrorForUnwritablePath(t *testing.T) {
+	restoreLog(t)
+	// A path whose parent is a regular file can never be opened for writing.
+	parent := filepath.Join(t.TempDir(), "not-a-dir")
+	if err := os.WriteFile(parent, []byte("x"), 0o600); err != nil {
+		t.Fatalf("seeding the file: %v", err)
+	}
+
+	if err := Init(filepath.Join(parent, "y509.log"), false); err == nil {
+		t.Error("Init() returned nil for a path under a regular file")
+	}
+}

--- a/internal/model/render_test.go
+++ b/internal/model/render_test.go
@@ -1,0 +1,198 @@
+package model
+
+import (
+	"strings"
+	"testing"
+
+	"charm.land/lipgloss/v2"
+)
+
+// sized returns a model with a viewport, since every renderer divides by the
+// width and a zero-width model exercises nothing.
+func sized(t *testing.T, certCount, width, height int) Model {
+	t.Helper()
+	m := *NewModel(createTestCertificates(certCount), loadTestConfig(t))
+	m.SetDimensions(width, height)
+	m.SetReady(true)
+	return m
+}
+
+func TestSetDimensionsIsReadableThroughTheGetters(t *testing.T) {
+	m := sized(t, 1, 120, 40)
+
+	if m.GetWidth() != 120 || m.GetHeight() != 40 {
+		t.Errorf("GetWidth()/GetHeight() = %d/%d, want 120/40", m.GetWidth(), m.GetHeight())
+	}
+}
+
+func TestCertItemFilterValue(t *testing.T) {
+	certs := createTestCertificates(1)
+
+	item := certItem{info: certs[0]}
+	if got := item.FilterValue(); got == "" {
+		t.Error("FilterValue() is empty; the list would have nothing to filter on")
+	}
+
+	// Filtering has to stay usable for a certificate with no common name, which
+	// is legal and does happen.
+	certs[0].Certificate.Subject.CommonName = ""
+	blank := certItem{info: certs[0]}
+	if got := blank.FilterValue(); got != "(no CN)" {
+		t.Errorf("FilterValue() = %q, want the placeholder for a blank CN", got)
+	}
+}
+
+func TestCertDelegateUpdateIsANoOp(t *testing.T) {
+	// The delegate has no state of its own; the model owns it all. If this ever
+	// returns a command, something has moved.
+	d := certDelegate{}
+	if cmd := d.Update(nil, nil); cmd != nil {
+		t.Error("certDelegate.Update returned a command")
+	}
+}
+
+func TestKeyMapHelpIsPopulated(t *testing.T) {
+	k := defaultKeyMap()
+
+	short := k.ShortHelp()
+	if len(short) == 0 {
+		t.Error("ShortHelp() is empty; the status bar hints would be blank")
+	}
+	full := k.FullHelp()
+	if len(full) == 0 {
+		t.Fatal("FullHelp() is empty; the help overlay would be blank")
+	}
+	// The overlay groups bindings into columns, so every group must carry some.
+	for i, group := range full {
+		if len(group) == 0 {
+			t.Errorf("FullHelp() group %d is empty", i)
+		}
+	}
+	// The overlay exists to show more than the status bar hint does.
+	var fullCount int
+	for _, group := range full {
+		fullCount += len(group)
+	}
+	if fullCount <= len(short) {
+		t.Errorf("FullHelp() lists %d bindings against ShortHelp()'s %d; the overlay should show more",
+			fullCount, len(short))
+	}
+}
+
+func TestRenderHelpViewMentionsTheProgram(t *testing.T) {
+	m := sized(t, 2, 100, 30)
+
+	got := m.renderHelpView()
+	if !strings.Contains(got, "y509") {
+		t.Errorf("help view does not name the program:\n%s", got)
+	}
+	if strings.TrimSpace(got) == "" {
+		t.Error("help view is blank")
+	}
+}
+
+func TestRenderTwoPanesFillsTheWidth(t *testing.T) {
+	m := sized(t, 3, 120, 40)
+
+	got := m.renderTwoPanes(20)
+	if strings.TrimSpace(got) == "" {
+		t.Fatal("renderTwoPanes produced nothing")
+	}
+	// The panes are joined horizontally, so each line has to carry both.
+	// The panes are joined horizontally, so the result must be at least as wide
+	// as the left pane alone would be.
+	if w := lipgloss.Width(got); w < m.GetWidth()/2 {
+		t.Errorf("rendered width %d is well under the model's %d; the panes did not join",
+			w, m.GetWidth())
+	}
+}
+
+func TestRenderSplashScreenAdaptsToTheTerminalSize(t *testing.T) {
+	tests := []struct {
+		name          string
+		width, height int
+	}{
+		{"comfortable", 120, 40},
+		{"narrow", CompactArtWidthThreshold - 1, 40},
+		{"short", 120, CompactArtHeightThreshold - 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := sized(t, 1, tt.width, tt.height)
+
+			got := m.renderSplashScreen()
+			if strings.TrimSpace(got) == "" {
+				t.Fatalf("splash screen is blank at %dx%d", tt.width, tt.height)
+			}
+			// A splash that overruns the terminal width wraps and turns into
+			// noise, which is the whole reason for the compact variant.
+			// Measure with lipgloss so the colour escapes do not count as width.
+			for _, line := range strings.Split(got, "\n") {
+				if w := lipgloss.Width(line); w > tt.width {
+					t.Errorf("line is %d wide at width %d: %q", w, tt.width, line)
+					break
+				}
+			}
+		})
+	}
+}
+
+func TestHandleValidateCommandOpensAnAlert(t *testing.T) {
+	m := sized(t, 2, 100, 30)
+
+	got := m.handleValidateCommand()
+
+	// The test chain is self-signed, so the trust store will reject it. Either
+	// way the user must end up looking at a popup rather than at nothing.
+	if got.viewMode != ViewPopup {
+		t.Errorf("viewMode = %v, want ViewPopup", got.viewMode)
+	}
+	if got.popupMessage == "" {
+		t.Error("popupMessage is empty; the popup would render blank")
+	}
+}
+
+func TestHandleValidateCommandWithNoCertificatesIsANoOp(t *testing.T) {
+	m := *NewModel(nil, loadTestConfig(t))
+	m.SetDimensions(100, 30)
+
+	got := m.handleValidateCommand()
+
+	if got.viewMode == ViewPopup {
+		t.Error("opened a popup with nothing loaded")
+	}
+}
+
+func TestHandleYankCommandCopiesPEMAndConfirms(t *testing.T) {
+	m := sized(t, 1, 100, 30)
+
+	got, cmd := m.handleYankCommand()
+
+	if cmd == nil {
+		t.Error("no command returned; nothing would reach the clipboard")
+	}
+	if got.viewMode != ViewPopup || got.popupType != PopupAlert {
+		t.Errorf("viewMode/popupType = %v/%v, want ViewPopup/PopupAlert", got.viewMode, got.popupType)
+	}
+	// The confirmation names what was copied and how much, which is how the user
+	// tells a successful yank from a silent one.
+	if !strings.Contains(got.popupMessage, "Copied PEM") {
+		t.Errorf("popupMessage = %q, want it to confirm the copy", got.popupMessage)
+	}
+	if !strings.Contains(got.popupMessage, "Bytes:") {
+		t.Errorf("popupMessage = %q, want it to report the size", got.popupMessage)
+	}
+}
+
+func TestHandleYankCommandWithNoCertificatesIsANoOp(t *testing.T) {
+	m := *NewModel(nil, loadTestConfig(t))
+
+	got, cmd := m.handleYankCommand()
+
+	if cmd != nil {
+		t.Error("returned a clipboard command with nothing selected")
+	}
+	if got.viewMode == ViewPopup {
+		t.Error("opened a popup with nothing loaded")
+	}
+}

--- a/internal/model/render_test.go
+++ b/internal/model/render_test.go
@@ -99,11 +99,11 @@ func TestRenderTwoPanesFillsTheWidth(t *testing.T) {
 		t.Fatal("renderTwoPanes produced nothing")
 	}
 	// The panes are joined horizontally, so each line has to carry both.
-	// The panes are joined horizontally, so the result must be at least as wide
-	// as the left pane alone would be.
-	if w := lipgloss.Width(got); w < m.GetWidth()/2 {
-		t.Errorf("rendered width %d is well under the model's %d; the panes did not join",
-			w, m.GetWidth())
+	// The two panes are sized to divide the viewport exactly, so anything other
+	// than the full width means one of them was dropped or mis-sized. A
+	// less-than check would let a missing right pane through.
+	if w := lipgloss.Width(got); w != m.GetWidth() {
+		t.Errorf("rendered width = %d, want the full %d", w, m.GetWidth())
 	}
 }
 

--- a/internal/version/version_ldflags_test.go
+++ b/internal/version/version_ldflags_test.go
@@ -1,0 +1,73 @@
+package version
+
+import "testing"
+
+// The exported getters read package-level variables that release builds stamp
+// through -ldflags. A test binary never gets those flags, so the interesting
+// branches are only reachable by setting the variables directly.
+func withVars(t *testing.T, v, commit, date string) {
+	t.Helper()
+	oldV, oldC, oldD := Version, GitCommit, BuildDate
+	t.Cleanup(func() { Version, GitCommit, BuildDate = oldV, oldC, oldD })
+	Version, GitCommit, BuildDate = v, commit, date
+}
+
+func TestGetFullVersionTruncatesLongCommit(t *testing.T) {
+	withVars(t, "v1.2.3", "0123456789abcdef", "2026-08-08T00:00:00Z")
+
+	want := "v1.2.3 (0123456) built on 2026-08-08T00:00:00Z"
+	if got := GetFullVersion(); got != want {
+		t.Errorf("GetFullVersion() = %q, want %q", got, want)
+	}
+}
+
+func TestGetFullVersionKeepsShortCommitWhole(t *testing.T) {
+	withVars(t, "v1.2.3", "abc123", "unknown")
+
+	want := "v1.2.3 (abc123)"
+	if got := GetFullVersion(); got != want {
+		t.Errorf("GetFullVersion() = %q, want %q", got, want)
+	}
+}
+
+func TestGetFullVersionOmitsUnknownFields(t *testing.T) {
+	withVars(t, "v1.2.3", "unknown", "unknown")
+
+	if got := GetFullVersion(); got != "v1.2.3" {
+		t.Errorf("GetFullVersion() = %q, want %q", got, "v1.2.3")
+	}
+}
+
+func TestGetShortVersionReturnsTagForReleases(t *testing.T) {
+	withVars(t, "v1.2.3", "unknown", "unknown")
+
+	if got := GetShortVersion(); got != "v1.2.3" {
+		t.Errorf("GetShortVersion() = %q, want %q", got, "v1.2.3")
+	}
+}
+
+func TestVersionKindPredicates(t *testing.T) {
+	tests := []struct {
+		version   string
+		isDev     bool
+		isRelease bool
+	}{
+		{"dev", true, false},
+		{"v1.2.3", false, true},
+		{"v1.2.3-rc.1", false, false},
+		{"v1.2.3-dirty", false, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.version, func(t *testing.T) {
+			withVars(t, tt.version, "unknown", "unknown")
+
+			if got := IsDevVersion(); got != tt.isDev {
+				t.Errorf("IsDevVersion() = %v, want %v", got, tt.isDev)
+			}
+			if got := IsReleaseVersion(); got != tt.isRelease {
+				t.Errorf("IsReleaseVersion() = %v, want %v", got, tt.isRelease)
+			}
+		})
+	}
+}

--- a/pkg/certificate/format_test.go
+++ b/pkg/certificate/format_test.go
@@ -1,0 +1,275 @@
+package certificate
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"errors"
+	"math/big"
+	"strings"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+func TestTrustLevelString(t *testing.T) {
+	tests := []struct {
+		level TrustLevel
+		want  string
+	}{
+		{TrustAnchored, "trusted"},
+		{TrustSelfAnchored, "self-anchored"},
+		{TrustBroken, "broken"},
+		{TrustLevel(99), "broken"}, // an unnamed level must not read as trusted
+	}
+	for _, tt := range tests {
+		if got := tt.level.String(); got != tt.want {
+			t.Errorf("TrustLevel(%d).String() = %q, want %q", tt.level, got, tt.want)
+		}
+	}
+}
+
+func TestFormatVerifyResultNil(t *testing.T) {
+	// validate prints this unconditionally, so a nil result must not panic.
+	got := FormatVerifyResult(nil)
+	if !strings.Contains(got, "could not be verified") {
+		t.Errorf("FormatVerifyResult(nil) = %q", got)
+	}
+}
+
+func TestFormatVerifyResultAnchored(t *testing.T) {
+	withAnchor := FormatVerifyResult(&VerifyResult{Level: TrustAnchored, Anchor: "Test CA"})
+	if !strings.Contains(withAnchor, "valid") || !strings.Contains(withAnchor, "Test CA") {
+		t.Errorf("output = %q, want it to report validity and name the anchor", withAnchor)
+	}
+
+	// An anchored result with no anchor name still has to read as a success.
+	bare := FormatVerifyResult(&VerifyResult{Level: TrustAnchored})
+	if !strings.Contains(bare, "valid") {
+		t.Errorf("output = %q, want it to report validity", bare)
+	}
+	if strings.Contains(bare, "Trust anchor:") {
+		t.Errorf("output = %q, want no empty anchor line", bare)
+	}
+}
+
+func TestFormatVerifyResultSelfAnchored(t *testing.T) {
+	got := FormatVerifyResult(&VerifyResult{
+		Level:  TrustSelfAnchored,
+		Anchor: "Internal CA",
+		Err:    errors.New("x509: certificate signed by unknown authority"),
+	})
+
+	// This is the case users misread most often, so the output has to say all
+	// three things: what happened, where it stopped, and what to do about it.
+	for _, want := range []string{"self-anchored", "Internal CA", "unknown authority", "--roots"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("output is missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestFormatVerifyResultBroken(t *testing.T) {
+	got := FormatVerifyResult(&VerifyResult{Level: TrustBroken, Err: errors.New("no certificates")})
+	if !strings.Contains(got, "broken") || !strings.Contains(got, "no certificates") {
+		t.Errorf("output = %q, want it to report breakage and the reason", got)
+	}
+
+	// A broken result with no error attached must still render.
+	if got := FormatVerifyResult(&VerifyResult{Level: TrustBroken}); !strings.Contains(got, "broken") {
+		t.Errorf("output = %q", got)
+	}
+}
+
+func TestChainProblemString(t *testing.T) {
+	tests := []struct {
+		problem ChainProblem
+		want    string
+	}{
+		{ProblemMissingIssuer, "missing issuer"},
+		{ProblemRedundantRoot, "redundant root"},
+		{ProblemOutOfOrder, "out of order"},
+		{ProblemDuplicate, "duplicate"},
+		{ProblemUnrelated, "unrelated"},
+		{ChainProblem(99), "unknown"},
+	}
+	for _, tt := range tests {
+		if got := tt.problem.String(); got != tt.want {
+			t.Errorf("ChainProblem(%d).String() = %q, want %q", tt.problem, got, tt.want)
+		}
+	}
+}
+
+func TestFormatChainReportSaysNothingWhenTheChainIsFine(t *testing.T) {
+	// Callers print the result unconditionally, so a clean chain must produce an
+	// empty string rather than a "no problems" banner.
+	if got := FormatChainReport(nil); got != "" {
+		t.Errorf("FormatChainReport(nil) = %q, want empty", got)
+	}
+	if got := FormatChainReport(&ChainReport{}); got != "" {
+		t.Errorf("FormatChainReport(clean) = %q, want empty", got)
+	}
+}
+
+func TestFormatChainReportListsFindingsAndFetchURLs(t *testing.T) {
+	got := FormatChainReport(&ChainReport{
+		Findings: []ChainFinding{
+			{
+				Problem:   ProblemMissingIssuer,
+				Subject:   "leaf.example.com",
+				Detail:    "the issuing certificate was not sent",
+				FetchURLs: []string{"http://aia.example.com/ca.crt"},
+			},
+			{
+				Problem: ProblemOutOfOrder,
+				Subject: "Test CA",
+				Detail:  "the leaf was not sent first",
+			},
+		},
+	})
+
+	for _, want := range []string{
+		"Chain as presented",
+		"missing issuer", "leaf.example.com", "the issuing certificate was not sent",
+		"http://aia.example.com/ca.crt",
+		"out of order", "Test CA",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("output is missing %q:\n%s", want, got)
+		}
+	}
+	if strings.HasSuffix(got, "\n") {
+		t.Error("output ends in a newline; the caller adds its own spacing")
+	}
+}
+
+func TestDisplayNameFallsBackToSerial(t *testing.T) {
+	named := &x509.Certificate{Subject: pkix.Name{CommonName: "has a name"}}
+	if got := displayName(named); got != "has a name" {
+		t.Errorf("displayName() = %q, want the common name", got)
+	}
+
+	anonymous := &x509.Certificate{SerialNumber: big.NewInt(4242)}
+	if got := displayName(anonymous); got != "serial 4242" {
+		t.Errorf("displayName() = %q, want the serial as a fallback", got)
+	}
+}
+
+func TestNameOrUnknown(t *testing.T) {
+	if got := nameOrUnknown(""); got != "(no common name)" {
+		t.Errorf("nameOrUnknown(\"\") = %q", got)
+	}
+	if got := nameOrUnknown("Test CA"); got != "Test CA" {
+		t.Errorf("nameOrUnknown() = %q, want it left alone", got)
+	}
+}
+
+func TestTLSVersionName(t *testing.T) {
+	tests := []struct {
+		version uint16
+		want    string
+	}{
+		{tls.VersionTLS13, "TLS 1.3"},
+		{tls.VersionTLS12, "TLS 1.2"},
+		{tls.VersionTLS11, "TLS 1.1"},
+		{tls.VersionTLS10, "TLS 1.0"},
+		{0x0200, "unknown (0x0200)"},
+	}
+	for _, tt := range tests {
+		r := &ConnectResult{Version: tt.version}
+		if got := r.TLSVersionName(); got != tt.want {
+			t.Errorf("TLSVersionName() for 0x%04x = %q, want %q", tt.version, got, tt.want)
+		}
+	}
+}
+
+func TestSetLoggerAcceptsNil(t *testing.T) {
+	t.Cleanup(func() { SetLogger(nil) })
+
+	// Passing nil must leave a usable no-op logger rather than a nil pointer the
+	// package would later dereference.
+	SetLogger(zap.NewNop())
+	SetLogger(nil)
+
+	// Any call that logs proves the logger is still usable.
+	if _, err := LoadCertificates("this-path-does-not-exist.pem"); err == nil {
+		t.Error("expected an error for a missing file")
+	}
+}
+
+func TestValidateChainLinksMarksAWellFormedChainGood(t *testing.T) {
+	ca, caKey := issue(t, "Test CA", true, nil, nil)
+	leaf, _ := issue(t, "leaf.example.com", false, ca, caKey)
+
+	certs := []*Info{{Certificate: leaf}, {Certificate: ca}}
+	ValidateChainLinks(certs)
+
+	for i, c := range certs {
+		if c.ValidationStatus != StatusGood {
+			t.Errorf("certs[%d] status = %v (err %v), want StatusGood", i, c.ValidationStatus, c.ValidationError)
+		}
+	}
+}
+
+func TestValidateChainLinksFlagsAnOrphan(t *testing.T) {
+	ca, caKey := issue(t, "Test CA", true, nil, nil)
+	leaf, _ := issue(t, "leaf.example.com", false, ca, caKey)
+
+	// The issuer is absent from the bundle, which is the single most common
+	// misconfiguration: a server that forgot its intermediate.
+	certs := []*Info{{Certificate: leaf}}
+	ValidateChainLinks(certs)
+
+	if certs[0].ValidationStatus != StatusMismatchedIssuer {
+		t.Errorf("status = %v, want StatusMismatchedIssuer", certs[0].ValidationStatus)
+	}
+	if certs[0].ValidationError == nil || !strings.Contains(certs[0].ValidationError.Error(), "Test CA") {
+		t.Errorf("error = %v, want it to name the missing issuer", certs[0].ValidationError)
+	}
+}
+
+func TestValidateChainLinksFlagsExpiry(t *testing.T) {
+	ca, caKey := issue(t, "Test CA", true, nil, nil)
+	leaf, _ := issue(t, "leaf.example.com", false, ca, caKey)
+
+	// Rewriting NotAfter in place is enough: the function reads the parsed
+	// fields, and expiry short-circuits before any signature check.
+	leaf.NotAfter = leaf.NotBefore
+
+	certs := []*Info{{Certificate: leaf}, {Certificate: ca}}
+	ValidateChainLinks(certs)
+
+	if certs[0].ValidationStatus != StatusExpired {
+		t.Errorf("status = %v, want StatusExpired", certs[0].ValidationStatus)
+	}
+}
+
+func TestValidateChainLinksResetsPreviousStatus(t *testing.T) {
+	ca, caKey := issue(t, "Test CA", true, nil, nil)
+	leaf, _ := issue(t, "leaf.example.com", false, ca, caKey)
+
+	// A stale failure from an earlier run must not survive re-validation, or the
+	// TUI keeps showing an error the user already fixed.
+	certs := []*Info{
+		{Certificate: leaf, ValidationStatus: StatusInvalidSignature, ValidationError: errors.New("stale")},
+		{Certificate: ca},
+	}
+	ValidateChainLinks(certs)
+
+	if certs[0].ValidationStatus != StatusGood || certs[0].ValidationError != nil {
+		t.Errorf("status = %v, err = %v; want the previous failure cleared",
+			certs[0].ValidationStatus, certs[0].ValidationError)
+	}
+}
+
+func TestValidateChainLinksAcceptsASelfSignedRoot(t *testing.T) {
+	ca, _ := issue(t, "Test CA", true, nil, nil)
+
+	certs := []*Info{{Certificate: ca}}
+	ValidateChainLinks(certs)
+
+	if certs[0].ValidationStatus != StatusGood {
+		t.Errorf("status = %v (err %v), want a self-signed root to pass",
+			certs[0].ValidationStatus, certs[0].ValidationError)
+	}
+}

--- a/pkg/certificate/format_test.go
+++ b/pkg/certificate/format_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 func TestTrustLevelString(t *testing.T) {
@@ -183,17 +185,31 @@ func TestTLSVersionName(t *testing.T) {
 	}
 }
 
-func TestSetLoggerAcceptsNil(t *testing.T) {
+func TestSetLoggerRoutesAndResets(t *testing.T) {
 	t.Cleanup(func() { SetLogger(nil) })
 
-	// Passing nil must leave a usable no-op logger rather than a nil pointer the
-	// package would later dereference.
-	SetLogger(zap.NewNop())
-	SetLogger(nil)
+	core, logs := observer.New(zapcore.DebugLevel)
+	SetLogger(zap.New(core))
 
-	// Any call that logs proves the logger is still usable.
+	// LoadCertificates logs when it cannot open the file, so a failed load is
+	// enough to prove diagnostics reach the logger that was installed.
 	if _, err := LoadCertificates("this-path-does-not-exist.pem"); err == nil {
-		t.Error("expected an error for a missing file")
+		t.Fatal("expected an error for a missing file")
+	}
+	installed := logs.Len()
+	if installed == 0 {
+		t.Fatal("nothing was recorded; SetLogger did not route the package diagnostics")
+	}
+
+	// Passing nil must leave a usable no-op logger rather than a nil pointer the
+	// package would later dereference, and nothing more may reach the old one.
+	SetLogger(nil)
+	if _, err := LoadCertificates("this-path-does-not-exist.pem"); err == nil {
+		t.Fatal("expected an error for a missing file")
+	}
+	if logs.Len() != installed {
+		t.Errorf("the replaced logger recorded %d more entries after SetLogger(nil)",
+			logs.Len()-installed)
 	}
 }
 

--- a/scripts/gen_demo_certs.go
+++ b/scripts/gen_demo_certs.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 // Package main provides a utility script to generate demo certificates.
 package main
 


### PR DESCRIPTION
Coverage was **64.7%** by `go tool cover`, and it is now **82.1%**, with a CI gate so it cannot drift back down.

The immediate reason is [awesome-go](https://github.com/avelino/awesome-go), which requires 80% before it will list a project. The more useful outcome is that several things which had no tests at all now do.

## Where the gap was

| package | before | after |
| ------- | -----: | ----: |
| `internal/cmd` | 20.4% | 76.4% |
| `internal/config` | 0% | 97.6% |
| `internal/logger` | 0% | 100% |
| `internal/model` | 66.6% | 75.1% |
| `internal/version` | 51.9% | 77.8% |
| `pkg/certificate` | 78.9% | 90.9% |

## What the new tests actually pin down

- **`verifyOptionsFromFlags` had no tests.** Neither did the guard that rejects `--no-system-roots` without `--roots`, nor the error that names an unreadable `--roots` file.
- **`ValidateChainLinks` had no tests**, despite deciding the status shown against every certificate in the TUI. Covered: a well-formed chain, a missing issuer (the forgotten-intermediate case), expiry, a self-signed root, and that a stale failure from a previous run gets cleared rather than sticking.
- **`FormatVerifyResult` had no tests.** The self-anchored wording is the output users misread most often, so there is now a test asserting it says all three things: what happened, where it stopped, and to pass `--roots`.
- **The connect path runs for real.** `startTLSServer` puts the generated test chain behind a `tls.Listen` on `127.0.0.1:0`, so `loadInput` and `connectFromFlags` are exercised with no DNS and no outbound traffic.
- **`validate` and `export` go through the real root command**, including the non-zero exit for a self-anchored chain, all four export formats, directory creation, and bad indexes.

## Things worth knowing

- A negative export index has to be passed after `--`, because pflag otherwise reads `-1` as a shorthand flag. The test uses that form and says why.
- `RootCmd` is a package singleton and cobra cannot reset one, so the runner snapshots and restores every flag value. Without that a `--roots` from one test silently changes the next.
- Certificate fixtures are generated per run rather than committed. Committed fixtures expire, and noticing expiry is the program's job.
- The splash-screen assertions measure with `lipgloss.Width`, so colour escapes do not count towards the terminal width.
- `scripts/gen_demo_certs.go` is now `//go:build ignore`. It is a standalone generator invoked as `go run` from the `demo-certs` target rather than part of the program, and it was pulling 51 uncovered statements into the total. `go run` still works, verified.

## The gate

`make test-coverage` writes a profile and fails below `COVERAGE_THRESHOLD` (80.0), and CI runs it as its own step. Confirmed it fails when the threshold is raised past the current number.

`-race` passes, `go vet` is clean, `golangci-lint` reports 0 issues.

Still outstanding for the awesome-go submission: it also wants a reachable Codecov or Coveralls report linked from the readme, which needs the app authorised on the repo first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded coverage across certificate validation, command-line input and flags, configuration, logging, rendering, version reporting, and export workflows.
  * Added integration tests for TLS fetching, trust roots, completion output, and certificate-chain handling.
  * Added runtime-generated certificate fixtures for reliable test scenarios.

* **Chores**
  * Added configurable coverage-threshold enforcement, defaulting to 80%.
  * Improved coverage reporting and excluded a certificate-generation utility from normal builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->