### PR TITLE
ci: add a Claude code review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,92 @@
+name: Claude code review
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+  id-token: write
+
+# A rapid re-push should supersede the in-flight review rather than post twice.
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    # Advisory, not a gate. A reviewer that cannot reach the API (expired token, empty
+    # credit balance, provider outage) says nothing about the change under review, so it
+    # must not be what blocks a merge. Read the job log when the review is missing.
+    continue-on-error: true
+    # Dependabot bumps are lockfile-only, so reviewing them just burns tokens.
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
+    steps:
+      # Keeps the job green (and silent) until the token is added to the repo secrets,
+      # instead of turning every PR red with an auth failure. A pull request from a fork
+      # cannot see the secret either, so this covers that case too.
+      - name: Check for a token
+        id: key
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        run: echo "present=${CLAUDE_CODE_OAUTH_TOKEN:+true}" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/checkout@v7
+        if: steps.key.outputs.present == 'true'
+        with:
+          fetch-depth: 1
+
+      - uses: anthropics/claude-code-action@v1
+        if: steps.key.outputs.present == 'true'
+        with:
+          # `claude setup-token` issues an OAuth token (sk-ant-oat01-...) that runs on the
+          # Claude subscription. It is not an API key and is rejected by the x-api-key
+          # header, so it has to go through this input rather than anthropic_api_key.
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Review this pull request. The PR branch is already checked out in the working
+            directory.
+
+            y509 is a Go TUI for reading X.509 certificate chains. It takes a PEM or DER
+            file, a live server (including STARTTLS for smtp, imap and postgres), or
+            stdin. `pkg/certificate` is the only exported package and holds the parsing,
+            the chain analysis and the trust verification. `internal/cmd` is the cobra
+            surface, `internal/model` is the Bubble Tea model, and `validate` is meant to
+            be usable as a CI gate.
+
+            Focus on:
+            - Correctness in certificate handling. This is security-adjacent code, so a
+              check that is skipped, a check that passes on empty input, and an error
+              that gets swallowed all matter more than style.
+            - Whether a change preserves the certificates in the order the server sent
+              them. Sorting the chain destroys the evidence of a mis-served chain, which
+              is the main thing the tool exists to show. `AnalyzeChain` sorts on the way
+              through and callers are expected to use its result rather than sorting
+              again.
+            - Trust decisions. A chain that links up but terminates at a root supplied in
+              the input itself is self-anchored, not valid, and `validate` must keep
+              exiting non-zero for it or it silently passes CI.
+            - `pkg/certificate` is exported, so a signature change there is a breaking
+              change for anyone importing it. Say so if you see one.
+            - Tests. `make test-coverage` fails below 80%, so a change that adds branches
+              should add cases. Prefer generated fixtures over committed certificates,
+              which expire.
+            - Consistency with the surrounding code: `cmd`/`internal`/`pkg` layout,
+              errors wrapped with `%w`, and the existing table-driven test style.
+
+            Report only what you can point at in the diff. Do not restate what the change
+            does, do not praise it, and skip nits that golangci-lint would already catch.
+            If the change looks sound, say so in one line rather than inventing findings.
+
+            Use `gh pr comment` for top-level feedback.
+            Use `mcp__github_inline_comment__create_inline_comment` (with `confirmed: true`)
+            to point at specific lines.
+            Only post GitHub comments, do not return the review as a message.
+
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"


### PR DESCRIPTION
Adds an automatic Claude review on every pull request.

## Where the shape comes from

Three of these already exist across the account, and they are not the same:

| repo | workflow | token present |
| ---- | -------- | ------------- |
| `i-watched-movies` | `claude-code-review.yml`, updated 2026-07-24 | yes |
| `wtfi2` | `claude-review.yml` + `claude.yml` | no, dormant |

This follows the `i-watched-movies` one, since it is the version actually running against a token and the one most recently revised. Carried over unchanged: skip dependabot, `concurrency` so a rapid re-push supersedes the in-flight review instead of posting twice, `continue-on-error` because a reviewer that cannot reach the API says nothing about the change and must not block a merge, and a token-presence check so the job stays green rather than turning every PR red.

## The prompt is written for y509

Copying the film-diary prompt would have produced a reviewer that knows nothing about this repo. It now points at the things that are specific here:

- Sorting a chain destroys the evidence of a mis-served one, which is the main thing the tool exists to show. `AnalyzeChain` sorts on the way through, and callers use its result rather than sorting again.
- A chain that terminates at a root supplied in its own input is self-anchored, not valid, and `validate` has to keep exiting non-zero or it silently passes CI.
- `pkg/certificate` is the only exported package, so a signature change there is breaking for importers.
- `make test-coverage` fails below 80%, so a change that adds branches should add cases, and fixtures should be generated rather than committed because committed certificates expire.

It is also told to report only what it can point at in the diff, to skip anything golangci-lint already catches, and to say so in one line when a change looks fine rather than inventing findings.

## Before it does anything

`CLAUDE_CODE_OAUTH_TOKEN` has to be added to this repo's secrets, generated with `claude setup-token`. It is an OAuth token that runs on the Claude subscription rather than an API key, which is why it goes through `claude_code_oauth_token` and not `anthropic_api_key`. Until then the job skips silently, which is also what happens for pull requests from forks, since they cannot read the secret.

YAML validated.