### PR TITLE
ci: skip bot pull requests and stop stacking review summaries

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -27,10 +27,14 @@ concurrency:
 jobs:
   review:
     # A pull request from a fork gets no secrets, so the job would fail on
-    # authentication rather than say anything useful. Drafts are skipped until
-    # they are marked ready, which is what the ready_for_review trigger is for.
+    # authentication rather than say anything useful. Dependabot is same-repo but
+    # is handed dependabot secrets rather than the repository's, so it would fail
+    # the token check and paint every dependency bump red; the type check keeps
+    # every bot out for the same reason. Drafts are skipped until they are marked
+    # ready, which is what the ready_for_review trigger is for.
     if: >-
       github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.user.type == 'User' &&
       github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -101,7 +105,10 @@ jobs:
                because committed certificates expire and noticing expiry is the job.
 
             Post findings as inline comments on the lines they concern. Use one
-            top-level comment for the summary. Be specific and cite
+            top-level comment for the summary, posted with
+            `gh pr comment --edit-last --create-if-none` so that a re-review
+            replaces the previous summary rather than stacking another one
+            underneath it. Be specific and cite
             `file:line`. If the diff is clean against all of the above, say so
             in one line rather than manufacturing nits.
 


### PR DESCRIPTION
CodeRabbit raised both of these on the workflow pull requests after they had already merged, so they land here instead.

**Bot pull requests.** The fork guard let Dependabot through, because a Dependabot pull request is same-repo. Dependabot workflows are handed dependabot secrets rather than the repository's, so `CLAUDE_CODE_OAUTH_TOKEN` came back empty, the token check failed, and every dependency bump got a red X. Requiring the author to be a `User` keeps Dependabot and every other generated pull request out, which is also where the review had the least to say.

**Stacked summaries.** The prompt asked for one top-level comment per run, so a branch pushed five times carried five stale summaries. It now asks for `gh pr comment --edit-last --create-if-none`.

Verified with `actionlint`; `zizmor` is clean where it runs.

Deliberately not done, from the same CodeRabbit batch:

- **`--tools` / `--disallowedTools` / `--permission-mode`.** The finding is technically right: `--allowedTools` is a permission allowlist, not a capability list, and `--tools` really does restrict the built-in set. But the action refuses to run whenever this file differs from the copy on the default branch, so a change to the agent's tool surface cannot be tested until after it merges, and the failure mode is a reviewer that quietly cannot read files while the check still goes green. That is the exact thing the header comment says this workflow is built to avoid. Worth doing deliberately, not blind.
- **Passing `github_token: ${{ github.token }}`.** Would narrow the action to this job's `contents: read` / `pull-requests: write` instead of the GitHub App's defaults, which is genuinely tighter, but it swaps the authentication path and the comment identity. Same untestable-until-merged problem.
- **An environment approval gate on the secret.** Every account with push access here is the owner, so the gate would add a manual approval to every pull request and protect against nobody.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Automated reviews now skip pull requests created by bots and other non-user accounts.
  * Review summaries now update an existing comment instead of creating multiple stacked comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->