### PR TITLE
fix(release): strip the quarantine bit in the Homebrew cask postflight

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -42,6 +42,12 @@ homebrew_casks:
   - name: y509
     binaries:
       - y509
+    hooks:
+      post:
+        install: |
+          if OS.mac?
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/y509"]
+          end
     manpages:
       - man/man1/y509.1
     completions:


### PR DESCRIPTION
The release binaries are unsigned, so Gatekeeper quarantines them and macOS refuses to run y509 after a fresh `brew install`.

Adds a postflight hook to the cask that clears `com.apple.quarantine` on the staged binary.

Verified with `goreleaser release --snapshot`, the generated cask now has:

```ruby
postflight do
  if OS.mac?
    system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/y509"]
  end
end
```

Signing and notarizing is the real fix, but that needs an Apple Developer account.

Closes #68

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved macOS installation by automatically removing the quarantine attribute from the installed `y509` binary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->