### PR TITLE
fix(ci): bump Go toolchain to 1.26.6 for stdlib vulnerability fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kanywst/y509
 
-go 1.26.5
+go 1.26.6
 
 tool (
 	github.com/golangci/golangci-lint/v2/cmd/golangci-lint


### PR DESCRIPTION
The `Vulnerability check` step has been failing on `main` and on every Dependabot PR. `govulncheck` finds two stdlib vulnerabilities that y509 actually reaches on go1.26.5:

| ID | Package | Reached via |
| --- | --- | --- |
| [GO-2026-6090](https://pkg.go.dev/vuln/GO-2026-6090) | `crypto/tls` | `certificate.FetchChain` → `tls.Conn.HandshakeContext` (`pkg/certificate/connect.go:159`) |
| [GO-2026-5972](https://pkg.go.dev/vuln/GO-2026-5972) | `encoding/asn1` | `certificate.describeUnknownPublicKey` → `asn1.Unmarshal` (`pkg/certificate/certificate.go:714`) |

Both are fixed in go1.26.6. Every workflow resolves the toolchain with `go-version-file: go.mod`, so bumping the directive is the whole fix.

Verified locally on go1.26.6: `go tool govulncheck ./...` reports no vulnerabilities, and `go build ./...` and `go test ./...` pass.

Note this will recur on the next Go security release, because the `go` directive pins an exact patch. brtc solves it with `check-latest: true` on `actions/setup-go`; worth considering here as a follow-up.