### PR TITLE
fix(deps): bump the go directive to 1.26.6 for stdlib CVE fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kanywst/y509
 
-go 1.26.5
+go 1.26.6
 
 tool (
 	github.com/golangci/golangci-lint/v2/cmd/golangci-lint


### PR DESCRIPTION
## What

Bump the `go` directive in `go.mod` from `1.26.5` to `1.26.6`.

## Why

Every workflow resolves its toolchain with `go-version-file: go.mod`, so CI was installing exactly Go 1.26.5. `make vulncheck` then failed on two standard-library vulnerabilities that govulncheck traced to real call sites in this repo:

| ID | Issue | Trace |
| --- | --- | --- |
| [GO-2026-6090](https://pkg.go.dev/vuln/GO-2026-6090) | crypto/tls: limit post-handshake messages | `certificate.FetchChain` -> `tls.Conn.HandshakeContext` (`pkg/certificate/connect.go:159`) |
| [GO-2026-5972](https://pkg.go.dev/vuln/GO-2026-5972) | encoding/asn1: enforce maximum recursion depth | `certificate.describeUnknownPublicKey` -> `asn1.Unmarshal` (`pkg/certificate/certificate.go:714`) |

Both are fixed in go1.26.6. This was invisible locally because the local toolchain was already 1.26.6; only CI pinned down to the vulnerable patch.

The failure blocks the two open Dependabot PRs (#70, #71), which should go green once this lands.

## Verification

- `make lint` -> 0 issues
- `make vulncheck` -> No vulnerabilities found, 0 called
- `go test ./...` -> all packages pass