### PR TITLE
feat(validate): add --json for machine-readable output

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,57 @@ is the whole point: the check is structural, so it cannot be papered over.
 It also reports a redundant root (a root the server should not be sending),
 certificates sent out of order, duplicates, and strangers in the bundle.
 
+### Machine-readable output
+
+`--json` writes the whole result to stdout, and nothing else does. The text
+report is replaced rather than added to, and the failure message goes to stderr,
+so the stream parses even when the check fails. The exit codes are unchanged.
+
+```bash
+y509 validate example.com:443 --json | jq .
+```
+
+```json
+{
+  "host": "example.com",
+  "trust": {
+    "level": "self-anchored",
+    "trusted": false,
+    "anchor": "Internal Root CA",
+    "error": "x509: certificate signed by unknown authority"
+  },
+  "presentation": {
+    "ok": false,
+    "findings": [
+      {
+        "problem": "missing issuer",
+        "subject": "*.example.com",
+        "detail": "the chain stops at a certificate that is not a CA; its issuer \"R13\" was never sent, so a client that does not chase AIA (curl, Go, Java) cannot build a chain",
+        "fetchUrls": ["http://r13.i.lencr.org/"]
+      }
+    ]
+  },
+  "chain": [{ "index": 0, "commonName": "*.example.com", "daysUntilExpiry": 43, "…": "…" }]
+}
+```
+
+This exists because the exit code cannot carry the answer. It collapses
+`self-anchored` and `broken` into the same non-zero, so a script cannot tell an
+internal PKI from a chain that does not link up — and it says nothing at all
+about how the chain was served, which is the finding you most likely came for:
+
+```bash
+# Fail the build on a chain that verifies but is mis-served.
+y509 validate example.com:443 --json | jq -e '.presentation.ok'
+
+# Warn 30 days out, without parsing prose.
+y509 validate example.com:443 --json | jq '.chain[0].daysUntilExpiry < 30'
+```
+
+`chain` is in the order the certificates were **presented**, not sorted, because
+sorting is what destroys the evidence `presentation` reports on. `level` and
+`problem` are strings, and `findings` is always an array, never `null`.
+
 ## Keybindings
 
 |     Key     | Action                                         |

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -3,7 +3,9 @@ package cmd
 
 import (
 	"crypto/x509"
+	"encoding/json"
 	"fmt"
+	"io"
 
 	"github.com/kanywst/y509/internal/logger"
 	"github.com/kanywst/y509/pkg/certificate"
@@ -20,7 +22,11 @@ var validateCmd = &cobra.Command{
 The chain is verified against the system trust store. A chain that links up but
 terminates at a root which is not trusted -- an internal PKI, or a bundle that
 is simply missing its root -- is reported as self-anchored rather than valid,
-and exits non-zero. Pass --roots to supply your own trust anchors.`,
+and exits non-zero. Pass --roots to supply your own trust anchors.
+
+--json writes the whole result to stdout as JSON, which is what a script wants:
+the exit code collapses "self-anchored" and "broken" into the same non-zero, and
+says nothing at all about how the chain was served.`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		source, err := loadInput(cmd, args)
@@ -61,14 +67,28 @@ and exits non-zero. Pass --roots to supply your own trust anchors.`,
 			return err
 		}
 
-		fmt.Println(certificate.FormatVerifyResult(result))
+		asJSON, err := cmd.Flags().GetBool("json")
+		if err != nil {
+			return err
+		}
 
-		// How the chain was presented is a separate question from whether it
-		// verifies, and a chain can be perfectly trusted while still being
-		// mis-served. Report it either way.
-		if presentation := certificate.FormatChainReport(report); presentation != "" {
-			fmt.Println()
-			fmt.Println(presentation)
+		if asJSON {
+			// Nothing else may go to stdout in this mode: the whole point is
+			// that the stream parses. The non-zero exit below still reports the
+			// failure, and cobra prints that to stderr.
+			if err := writeJSONReport(cmd.OutOrStdout(), source.Host, report, result); err != nil {
+				return err
+			}
+		} else {
+			fmt.Println(certificate.FormatVerifyResult(result))
+
+			// How the chain was presented is a separate question from whether it
+			// verifies, and a chain can be perfectly trusted while still being
+			// mis-served. Report it either way.
+			if presentation := certificate.FormatChainReport(report); presentation != "" {
+				fmt.Println()
+				fmt.Println(presentation)
+			}
 		}
 
 		logger.Log.Info("Certificate chain validation result",
@@ -84,6 +104,24 @@ and exits non-zero. Pass --roots to supply your own trust anchors.`,
 		}
 		return nil
 	},
+}
+
+// writeJSONReport renders the machine-readable report.
+//
+// It is indented and newline-terminated because the overwhelmingly likely
+// consumer is a human reading a CI log or piping into jq, and neither is served
+// by one long line.
+func writeJSONReport(w io.Writer, host string, report *certificate.ChainReport, result *certificate.VerifyResult) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	// Certificate subjects and SANs are attacker-controlled strings, and Go's
+	// default HTML escaping would mangle them into < sequences for no
+	// benefit outside a browser.
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(certificate.NewJSONReport(host, report, result)); err != nil {
+		return fmt.Errorf("failed to write JSON report: %w", err)
+	}
+	return nil
 }
 
 // verifyOptionsFromFlags builds the verification options from the trust flags.
@@ -127,5 +165,6 @@ func init() {
 	validateCmd.Flags().String("roots", "", "PEM file of additional trust anchors")
 	validateCmd.Flags().Bool("no-system-roots", false, "Do not trust the system store; use only --roots")
 	validateCmd.Flags().String("host", "", "Also check that the leaf is valid for this hostname")
+	validateCmd.Flags().Bool("json", false, "Emit the result as JSON instead of text")
 	RootCmd.AddCommand(validateCmd)
 }

--- a/internal/cmd/validate_json_test.go
+++ b/internal/cmd/validate_json_test.go
@@ -1,0 +1,169 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// runValidateJSON dispatches `validate --json` and returns stdout on its own.
+//
+// runRoot concatenates stdout with cobra's writer, which is fine for prose but
+// useless here: the whole claim being tested is that the stream parses, and a
+// helper that blends an error message into it would test the opposite.
+func runValidateJSON(t *testing.T, args ...string) (string, string, error) {
+	t.Helper()
+	restoreFlags(t)
+
+	var out, errOut bytes.Buffer
+	RootCmd.SetOut(&out)
+	RootCmd.SetErr(&errOut)
+	// Otherwise cobra writes the returned error, and the usage text, to the
+	// same writer the report goes to. Execute() sets both in production.
+	silenceErrors, silenceUsage := RootCmd.SilenceErrors, RootCmd.SilenceUsage
+	RootCmd.SilenceErrors, RootCmd.SilenceUsage = true, true
+	t.Cleanup(func() {
+		RootCmd.SilenceErrors, RootCmd.SilenceUsage = silenceErrors, silenceUsage
+	})
+
+	RootCmd.SetArgs(append([]string{"validate", "--json"}, args...))
+	err := RootCmd.Execute()
+
+	return out.String(), errOut.String(), err
+}
+
+// decode fails the test unless the output parses as the report.
+func decode(t *testing.T, out string) map[string]any {
+	t.Helper()
+
+	var report map[string]any
+	if err := json.Unmarshal([]byte(out), &report); err != nil {
+		t.Fatalf("stdout does not parse as JSON: %v\n%s", err, out)
+	}
+	return report
+}
+
+// TestValidateJSONStdoutIsOnlyJSON is the contract that makes the flag worth
+// having: a consumer pipes stdout into jq, so nothing human-readable may share
+// the stream -- not even on the failure path, which is the common case for a
+// command whose job is to find problems.
+func TestValidateJSONStdoutIsOnlyJSON(t *testing.T) {
+	chain := newTestChain(t)
+	path := write(t, "chain.pem", chain.ChainPEM)
+
+	// This chain is anchored at its own untrusted root, so validate exits
+	// non-zero. That is precisely when stdout must still parse.
+	out, _, err := runValidateJSON(t, path)
+	if err == nil {
+		t.Fatal("validate exited 0 for a chain anchored at an untrusted root")
+	}
+
+	report := decode(t, out)
+
+	// The emoji and the prose belong to the text renderer, and leaking either
+	// one would mean the two output paths had been wired together.
+	for _, leak := range []string{"✅", "⚠", "❌", "Certificate chain is", "Chain as presented"} {
+		if strings.Contains(out, leak) {
+			t.Errorf("the human-readable output leaked into the JSON stream: %q\n%s", leak, out)
+		}
+	}
+
+	trust, ok := report["trust"].(map[string]any)
+	if !ok {
+		t.Fatalf("trust is missing: %#v", report)
+	}
+	if trust["level"] != "self-anchored" {
+		t.Errorf("level = %#v, want \"self-anchored\"", trust["level"])
+	}
+	if trust["trusted"] != false {
+		t.Errorf("trusted = %#v, want false", trust["trusted"])
+	}
+}
+
+// TestValidateJSONDistinguishesSelfAnchoredFromBroken is the reason the flag
+// exists. Both exit 1, so the exit code alone cannot tell an internal PKI apart
+// from a chain that does not link up at all.
+func TestValidateJSONDistinguishesSelfAnchoredFromBroken(t *testing.T) {
+	chain := newTestChain(t)
+
+	// The leaf on its own: no issuer was supplied, so the chain does not build.
+	leafOnly := write(t, "leaf.pem", chain.LeafPEM)
+	out, _, err := runValidateJSON(t, leafOnly)
+	if err == nil {
+		t.Fatal("validate exited 0 for a chain that does not link up")
+	}
+	broken := decode(t, out)["trust"].(map[string]any)["level"]
+
+	// The same leaf with its root: links up, but the root is not trusted.
+	full := write(t, "chain.pem", chain.ChainPEM)
+	out, _, err = runValidateJSON(t, full)
+	if err == nil {
+		t.Fatal("validate exited 0 for a self-anchored chain")
+	}
+	selfAnchored := decode(t, out)["trust"].(map[string]any)["level"]
+
+	if broken == selfAnchored {
+		t.Fatalf("both chains reported %q; the exit code already collapses them, "+
+			"so JSON that does the same adds nothing", broken)
+	}
+	if selfAnchored != "self-anchored" {
+		t.Errorf("level = %#v, want \"self-anchored\"", selfAnchored)
+	}
+}
+
+// TestValidateJSONOnATrustedChain checks the success path, including that the
+// findings list is an array rather than null.
+func TestValidateJSONOnATrustedChain(t *testing.T) {
+	chain := newTestChain(t)
+	dir := t.TempDir()
+	chainPath := filepath.Join(dir, "chain.pem")
+	rootsPath := filepath.Join(dir, "roots.pem")
+	if err := os.WriteFile(chainPath, chain.ChainPEM, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(rootsPath, chain.CAPEM, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	out, _, err := runValidateJSON(t, chainPath, "--roots", rootsPath, "--no-system-roots")
+	if err != nil {
+		t.Fatalf("validate failed with its own CA supplied as an anchor: %v\n%s", err, out)
+	}
+
+	report := decode(t, out)
+	trust := report["trust"].(map[string]any)
+	if trust["trusted"] != true {
+		t.Errorf("trusted = %#v, want true", trust["trusted"])
+	}
+
+	presentation, ok := report["presentation"].(map[string]any)
+	if !ok {
+		t.Fatalf("presentation is missing: %#v", report)
+	}
+	if _, ok := presentation["findings"].([]any); !ok {
+		t.Errorf("findings is %#v, want an array even when empty", presentation["findings"])
+	}
+
+	certs, ok := report["chain"].([]any)
+	if !ok || len(certs) == 0 {
+		t.Fatalf("chain is %#v, want the certificates", report["chain"])
+	}
+}
+
+// TestValidateWithoutJSONStaysHumanReadable: the flag is additive, and the
+// default output must not have changed shape.
+func TestValidateWithoutJSONStaysHumanReadable(t *testing.T) {
+	chain := newTestChain(t)
+	path := write(t, "chain.pem", chain.ChainPEM)
+
+	out, _ := runRoot(t, "validate", path)
+	if strings.HasPrefix(strings.TrimSpace(out), "{") {
+		t.Errorf("validate emitted JSON without --json:\n%s", out)
+	}
+	if !strings.Contains(out, "Certificate chain is") {
+		t.Errorf("the text report is missing:\n%s", out)
+	}
+}

--- a/pkg/certificate/report.go
+++ b/pkg/certificate/report.go
@@ -1,0 +1,228 @@
+package certificate
+
+import (
+	"crypto/x509"
+	"time"
+)
+
+// The JSON types below are a deliberate translation layer rather than json tags
+// bolted onto the internal structs.
+//
+// TrustLevel and ChainProblem are integer constants whose numeric values exist
+// only to make iota work; marshalling them directly would publish `"level": 2`
+// as an API contract and break every consumer the moment a constant is
+// inserted. Everything crossing this boundary is therefore a string, a
+// timestamp, or a bool, and the field set is chosen rather than inherited.
+
+// JSONReport is the machine-readable form of a validate run.
+//
+// It answers the two questions validate asks, separately: whether the chain
+// verifies (Trust) and whether it was served correctly (Presentation). A chain
+// can be trusted and still mis-served, so a consumer that only looks at Trust
+// is throwing away the finding it most likely came for.
+type JSONReport struct {
+	// Host is the server the chain came from, empty for a file or stdin.
+	Host string `json:"host,omitempty"`
+	// Trust is the verification outcome against the configured trust anchors.
+	Trust JSONTrust `json:"trust"`
+	// Presentation is how the chain was served, judged structurally.
+	Presentation JSONPresentation `json:"presentation"`
+	// Chain is the certificates in the order they were presented -- the order a
+	// server sent them, or the order they appear in a file. It is not sorted,
+	// because sorting is what destroys the evidence Presentation reports on.
+	Chain []JSONCertificate `json:"chain"`
+}
+
+// JSONTrust is the verification outcome.
+type JSONTrust struct {
+	// Level is "trusted", "self-anchored" or "broken".
+	//
+	// The distinction between the latter two is the reason this field exists:
+	// both exit non-zero, so an exit code alone cannot tell an internal PKI
+	// apart from a genuinely broken chain.
+	Level string `json:"level"`
+	// Trusted is true only for "trusted", mirroring the exit status for a
+	// consumer that wants a single boolean.
+	Trusted bool `json:"trusted"`
+	// Anchor is the common name of the root the chain terminated at, when one
+	// was found.
+	Anchor string `json:"anchor,omitempty"`
+	// Error is why the chain is not anchored, set for every level below
+	// "trusted" -- including "self-anchored", where it explains why the chain
+	// is not publicly trusted.
+	Error string `json:"error,omitempty"`
+}
+
+// JSONPresentation is how the chain was served, as opposed to whether it
+// verifies.
+type JSONPresentation struct {
+	// OK reports whether the chain was presented correctly.
+	OK bool `json:"ok"`
+	// Findings are the problems with how it was presented, in the order they
+	// were discovered. Always an array, never null, so a consumer can range
+	// over it unconditionally.
+	Findings []JSONFinding `json:"findings"`
+}
+
+// JSONFinding is one presentation problem, tied to the certificate it concerns.
+type JSONFinding struct {
+	// Problem is the short name: "missing issuer", "redundant root",
+	// "out of order", "duplicate" or "unrelated".
+	Problem string `json:"problem"`
+	// Subject is the common name of the certificate concerned.
+	Subject string `json:"subject"`
+	// Detail explains the finding in a sentence.
+	Detail string `json:"detail"`
+	// FetchURLs are the AIA CA-Issuers URLs that would supply a missing issuer.
+	// Only set for a missing issuer.
+	FetchURLs []string `json:"fetchUrls,omitempty"`
+}
+
+// JSONCertificate is one certificate, reduced to the fields a script is likely
+// to gate on.
+//
+// It is deliberately not a full dump of x509.Certificate: this is an API
+// contract, and every field added is a field that has to keep working.
+type JSONCertificate struct {
+	// Index is the position in the chain as presented, leaf first when the
+	// sender got the order right.
+	Index int `json:"index"`
+	// Subject is the full RFC 2253 subject.
+	Subject string `json:"subject"`
+	// CommonName is the subject common name on its own, which is what the
+	// human-readable output keys off.
+	CommonName string `json:"commonName,omitempty"`
+	// Issuer is the full RFC 2253 issuer.
+	Issuer string `json:"issuer"`
+	// SerialNumber is hex-encoded, matching how openssl and the CAs print it.
+	SerialNumber string `json:"serialNumber"`
+	// NotBefore and NotAfter are the validity window, in RFC 3339.
+	NotBefore time.Time `json:"notBefore"`
+	NotAfter  time.Time `json:"notAfter"`
+	// DaysUntilExpiry counts whole days from now to NotAfter, negative once the
+	// certificate has expired. This is the field an expiry monitor wants.
+	DaysUntilExpiry int `json:"daysUntilExpiry"`
+	// Expired reports whether NotAfter is already in the past.
+	Expired bool `json:"expired"`
+	// ValidityDays is the certificate's total lifetime.
+	ValidityDays int `json:"validityDays"`
+	// ExceedsCABMaxLifetime reports a subscriber certificate whose lifetime is
+	// longer than the CA/Browser Forum maximum. CA certificates are exempt, so
+	// it is always false for them.
+	ExceedsCABMaxLifetime bool `json:"exceedsCabMaxLifetime"`
+	// IsCA is the basic constraints CA bit.
+	IsCA bool `json:"isCa"`
+	// SelfSigned reports whether the subject and issuer match.
+	SelfSigned bool `json:"selfSigned"`
+	// DNSNames and IPAddresses are the subject alternative names, which is what
+	// hostname coverage is actually checked against.
+	DNSNames    []string `json:"dnsNames,omitempty"`
+	IPAddresses []string `json:"ipAddresses,omitempty"`
+	// KeyAlgorithm and SignatureAlgorithm name the crypto in use, so a script
+	// can flag a deprecated algorithm.
+	KeyAlgorithm       string `json:"keyAlgorithm"`
+	SignatureAlgorithm string `json:"signatureAlgorithm"`
+	// FingerprintSHA256 is the hex SHA-256 of the DER, which is how a
+	// certificate is pinned and compared across runs.
+	FingerprintSHA256 string `json:"fingerprintSha256"`
+}
+
+// NewJSONReport assembles the machine-readable report.
+//
+// report must be the analysis of the chain as presented, and result the
+// verification outcome for the same chain. host is the server that was
+// contacted, empty for a file or stdin.
+func NewJSONReport(host string, report *ChainReport, result *VerifyResult) *JSONReport {
+	out := &JSONReport{
+		Host: host,
+		// Findings and Chain are initialised to empty rather than left nil so
+		// they marshal as [] instead of null. A consumer ranging over a null
+		// gets an unhelpful surprise in most languages, and "no findings" is
+		// the common case.
+		Presentation: JSONPresentation{OK: true, Findings: []JSONFinding{}},
+		Chain:        []JSONCertificate{},
+	}
+
+	if result != nil {
+		out.Trust = JSONTrust{
+			Level:   result.Level.String(),
+			Trusted: result.Level == TrustAnchored,
+			Anchor:  result.Anchor,
+		}
+		if result.Err != nil {
+			out.Trust.Error = result.Err.Error()
+		}
+	}
+
+	if report == nil {
+		return out
+	}
+
+	out.Presentation.OK = report.OK()
+	for _, finding := range report.Findings {
+		out.Presentation.Findings = append(out.Presentation.Findings, JSONFinding{
+			Problem:   finding.Problem.String(),
+			Subject:   finding.Subject,
+			Detail:    finding.Detail,
+			FetchURLs: finding.FetchURLs,
+		})
+	}
+
+	now := time.Now()
+	for i, cert := range report.Sent {
+		if cert == nil {
+			continue
+		}
+		out.Chain = append(out.Chain, newJSONCertificate(i, cert, now))
+	}
+
+	return out
+}
+
+// newJSONCertificate reduces one certificate to the JSON contract.
+func newJSONCertificate(index int, cert *x509.Certificate, now time.Time) JSONCertificate {
+	entry := JSONCertificate{
+		Index:                 index,
+		Subject:               cert.Subject.String(),
+		CommonName:            cert.Subject.CommonName,
+		Issuer:                cert.Issuer.String(),
+		NotBefore:             cert.NotBefore,
+		NotAfter:              cert.NotAfter,
+		DaysUntilExpiry:       daysUntil(cert.NotAfter, now),
+		Expired:               cert.NotAfter.Before(now),
+		ValidityDays:          ValidityPeriodDays(cert),
+		ExceedsCABMaxLifetime: ExceedsCABMaxLifetime(cert),
+		IsCA:                  cert.IsCA,
+		SelfSigned:            cert.Subject.String() == cert.Issuer.String(),
+		DNSNames:              cert.DNSNames,
+		KeyAlgorithm:          cert.PublicKeyAlgorithm.String(),
+		SignatureAlgorithm:    cert.SignatureAlgorithm.String(),
+		FingerprintSHA256:     FormatFingerprint(cert),
+	}
+
+	if cert.SerialNumber != nil {
+		entry.SerialNumber = cert.SerialNumber.Text(16)
+	}
+
+	for _, ip := range cert.IPAddresses {
+		entry.IPAddresses = append(entry.IPAddresses, ip.String())
+	}
+
+	return entry
+}
+
+// daysUntil counts whole days from now to t, rounding towards minus infinity so
+// a certificate that expires in twelve hours reports 0 rather than 1.
+//
+// Like ValidityPeriodDays this works in Unix seconds rather than time.Duration,
+// which is int64 nanoseconds and overflows at ~292 years -- well short of the
+// 9999-12-31 "no expiry" convention.
+func daysUntil(t, now time.Time) int {
+	const secsPerDay = 24 * 60 * 60
+	secs := t.Unix() - now.Unix()
+	days := secs / secsPerDay
+	if secs < 0 && secs%secsPerDay != 0 {
+		days--
+	}
+	return int(days)
+}

--- a/pkg/certificate/report_test.go
+++ b/pkg/certificate/report_test.go
@@ -1,0 +1,275 @@
+package certificate
+
+import (
+	"crypto/x509"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+// marshal renders a report the way the command does, and returns both the raw
+// bytes and the generic decoding, so a test can assert on the wire form rather
+// than on the Go structs it was built from. Asserting on the structs would pass
+// even if every json tag were wrong.
+func marshal(t *testing.T, report *JSONReport) (string, map[string]any) {
+	t.Helper()
+
+	var sb strings.Builder
+	enc := json.NewEncoder(&sb)
+	enc.SetIndent("", "  ")
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(report); err != nil {
+		t.Fatalf("the report does not marshal: %v", err)
+	}
+
+	var decoded map[string]any
+	if err := json.Unmarshal([]byte(sb.String()), &decoded); err != nil {
+		t.Fatalf("the report does not round-trip: %v", err)
+	}
+	return sb.String(), decoded
+}
+
+// TestJSONReport_LevelsAreStrings is the contract this whole type exists to
+// protect. TrustLevel and ChainProblem are iota constants, and marshalling them
+// directly would publish their numeric values as an API -- which then breaks
+// the moment a constant is inserted in the middle.
+func TestJSONReport_LevelsAreStrings(t *testing.T) {
+	for _, tc := range []struct {
+		level TrustLevel
+		want  string
+	}{
+		{TrustAnchored, "trusted"},
+		{TrustSelfAnchored, "self-anchored"},
+		{TrustBroken, "broken"},
+	} {
+		report := NewJSONReport("", nil, &VerifyResult{Level: tc.level})
+		_, decoded := marshal(t, report)
+
+		trust, ok := decoded["trust"].(map[string]any)
+		if !ok {
+			t.Fatalf("trust is not an object: %#v", decoded["trust"])
+		}
+		if got := trust["level"]; got != tc.want {
+			t.Errorf("level = %#v, want %q", got, tc.want)
+		}
+	}
+}
+
+// TestJSONReport_TrustedMirrorsTheExitCode: the boolean is the convenience
+// field, and it must agree with the level rather than drift from it.
+func TestJSONReport_TrustedMirrorsTheExitCode(t *testing.T) {
+	for _, level := range []TrustLevel{TrustAnchored, TrustSelfAnchored, TrustBroken} {
+		report := NewJSONReport("", nil, &VerifyResult{Level: level})
+		want := level == TrustAnchored
+		if report.Trust.Trusted != want {
+			t.Errorf("level %s: trusted = %v, want %v", level, report.Trust.Trusted, want)
+		}
+	}
+}
+
+// TestJSONReport_SelfAnchoredCarriesItsReason is the distinction the exit code
+// cannot make: self-anchored and broken both exit 1, so a consumer needs the
+// level and the error to tell an internal PKI apart from a real failure.
+func TestJSONReport_SelfAnchoredCarriesItsReason(t *testing.T) {
+	report := NewJSONReport("", nil, &VerifyResult{
+		Level:  TrustSelfAnchored,
+		Anchor: "Internal Root CA",
+		Err:    errors.New("x509: certificate signed by unknown authority"),
+	})
+
+	if report.Trust.Level != "self-anchored" {
+		t.Errorf("level = %q", report.Trust.Level)
+	}
+	if report.Trust.Anchor != "Internal Root CA" {
+		t.Errorf("anchor = %q", report.Trust.Anchor)
+	}
+	if !strings.Contains(report.Trust.Error, "unknown authority") {
+		t.Errorf("error = %q, want the trust store's reason", report.Trust.Error)
+	}
+}
+
+// TestJSONReport_EmptyFindingsMarshalAsArray guards the null-vs-[] trap: "no
+// findings" is the common case, and a consumer ranging over a null gets an
+// unhelpful surprise in most languages.
+func TestJSONReport_EmptyFindingsMarshalAsArray(t *testing.T) {
+	report := NewJSONReport("", nil, &VerifyResult{Level: TrustAnchored})
+	raw, decoded := marshal(t, report)
+
+	if strings.Contains(raw, "null") {
+		t.Errorf("the report contains a null:\n%s", raw)
+	}
+
+	presentation, ok := decoded["presentation"].(map[string]any)
+	if !ok {
+		t.Fatalf("presentation is not an object: %#v", decoded["presentation"])
+	}
+	if _, ok := presentation["findings"].([]any); !ok {
+		t.Errorf("findings is not an array: %#v", presentation["findings"])
+	}
+	if _, ok := decoded["chain"].([]any); !ok {
+		t.Errorf("chain is not an array: %#v", decoded["chain"])
+	}
+}
+
+// TestJSONReport_TrustedChainCanStillBeMisserved is the headline case, and the
+// reason a consumer must not stop at the trust level: incomplete-chain.badssl.com
+// verifies on a platform that chases AIA and is still misconfigured.
+func TestJSONReport_TrustedChainCanStillBeMisserved(t *testing.T) {
+	root, rootKey := issue(t, "Root CA", true, nil, nil)
+	intermediate, intermediateKey := issue(t, "Issuing CA", true, root, rootKey)
+	leaf, _ := issue(t, "leaf.example.com", false, intermediate, intermediateKey)
+
+	// Only the leaf is sent, so the intermediate is missing.
+	chainReport := AnalyzeChain([]*x509.Certificate{leaf})
+	report := NewJSONReport("leaf.example.com", chainReport, &VerifyResult{Level: TrustAnchored})
+
+	if !report.Trust.Trusted {
+		t.Fatal("the fixture is meant to be trusted")
+	}
+	if report.Presentation.OK {
+		t.Fatal("a chain missing its intermediate was reported as correctly served")
+	}
+
+	var found bool
+	for _, finding := range report.Presentation.Findings {
+		if finding.Problem == "missing issuer" {
+			found = true
+			if !strings.Contains(finding.Detail, "Issuing CA") {
+				t.Errorf("the finding does not name the missing issuer: %q", finding.Detail)
+			}
+		}
+	}
+	if !found {
+		t.Errorf("no missing-issuer finding; got %#v", report.Presentation.Findings)
+	}
+}
+
+// TestJSONReport_ChainIsInThePresentedOrder: sorting is what destroys the
+// evidence, so the emitted chain must be the one that was sent, and the indices
+// must match it.
+func TestJSONReport_ChainIsInThePresentedOrder(t *testing.T) {
+	root, rootKey := issue(t, "Root CA", true, nil, nil)
+	intermediate, intermediateKey := issue(t, "Issuing CA", true, root, rootKey)
+	leaf, _ := issue(t, "leaf.example.com", false, intermediate, intermediateKey)
+
+	// Deliberately backwards: root first, leaf last.
+	sent := []*x509.Certificate{root, intermediate, leaf}
+	report := NewJSONReport("", AnalyzeChain(sent), &VerifyResult{Level: TrustSelfAnchored})
+
+	if len(report.Chain) != len(sent) {
+		t.Fatalf("chain has %d entries, want %d", len(report.Chain), len(sent))
+	}
+	for i, entry := range report.Chain {
+		if entry.Index != i {
+			t.Errorf("entry %d has index %d", i, entry.Index)
+		}
+		if entry.CommonName != sent[i].Subject.CommonName {
+			t.Errorf("entry %d is %q, want %q (the order as presented)",
+				i, entry.CommonName, sent[i].Subject.CommonName)
+		}
+	}
+}
+
+// TestJSONReport_CertificateFields checks the fields a script actually gates on.
+func TestJSONReport_CertificateFields(t *testing.T) {
+	root, rootKey := issue(t, "Root CA", true, nil, nil)
+	leaf, _ := issue(t, "leaf.example.com", false, root, rootKey)
+
+	report := NewJSONReport("", AnalyzeChain([]*x509.Certificate{leaf, root}), nil)
+	if len(report.Chain) != 2 {
+		t.Fatalf("chain has %d entries, want 2", len(report.Chain))
+	}
+
+	gotLeaf, gotRoot := report.Chain[0], report.Chain[1]
+
+	if gotLeaf.IsCA {
+		t.Error("the leaf is reported as a CA")
+	}
+	if gotLeaf.SelfSigned {
+		t.Error("the leaf is reported as self-signed")
+	}
+	if !gotRoot.IsCA || !gotRoot.SelfSigned {
+		t.Errorf("the root is not reported as a self-signed CA: isCa=%v selfSigned=%v",
+			gotRoot.IsCA, gotRoot.SelfSigned)
+	}
+	if gotLeaf.Expired {
+		t.Error("a freshly issued certificate is reported as expired")
+	}
+	// issue() mints a NotAfter 24 hours out, so the count is 1 -- or 0 if the
+	// clock crossed a second boundary between minting the certificate and
+	// building the report. Both are correct; pinning either one makes the test
+	// flaky. The arithmetic itself is pinned in
+	// TestJSONReport_ExpiredCertificateCountsBackwards, which supplies its own
+	// "now" and so has no race to lose.
+	if gotLeaf.DaysUntilExpiry != 1 && gotLeaf.DaysUntilExpiry != 0 {
+		t.Errorf("daysUntilExpiry = %d, want 1 (or 0) for a certificate expiring in 24h",
+			gotLeaf.DaysUntilExpiry)
+	}
+	if len(gotLeaf.DNSNames) != 1 || gotLeaf.DNSNames[0] != "leaf.example.com" {
+		t.Errorf("dnsNames = %v", gotLeaf.DNSNames)
+	}
+	if gotLeaf.KeyAlgorithm != "ECDSA" {
+		t.Errorf("keyAlgorithm = %q", gotLeaf.KeyAlgorithm)
+	}
+	// The fingerprint is what a consumer pins on, so it must be the same hex
+	// SHA-256 the rest of the tool prints.
+	if gotLeaf.FingerprintSHA256 != FormatFingerprint(leaf) {
+		t.Errorf("fingerprintSha256 = %q, want %q",
+			gotLeaf.FingerprintSHA256, FormatFingerprint(leaf))
+	}
+	// Hex, matching openssl and the CAs, not the decimal big.Int default.
+	if gotLeaf.SerialNumber != leaf.SerialNumber.Text(16) {
+		t.Errorf("serialNumber = %q, want the hex form %q",
+			gotLeaf.SerialNumber, leaf.SerialNumber.Text(16))
+	}
+}
+
+// TestJSONReport_ExpiredCertificateCountsBackwards: an expiry monitor needs to
+// know how far past due a certificate is, so the count must go negative rather
+// than clamp at zero.
+func TestJSONReport_ExpiredCertificateCountsBackwards(t *testing.T) {
+	now := time.Now()
+
+	for _, tc := range []struct {
+		name     string
+		notAfter time.Time
+		want     int
+	}{
+		{"expires in ten days", now.AddDate(0, 0, 10).Add(time.Hour), 10},
+		{"expires in twelve hours", now.Add(12 * time.Hour), 0},
+		{"expired two hours ago", now.Add(-2 * time.Hour), -1},
+		{"expired five days ago", now.AddDate(0, 0, -5).Add(-time.Hour), -6},
+	} {
+		if got := daysUntil(tc.notAfter, now); got != tc.want {
+			t.Errorf("%s: daysUntil = %d, want %d", tc.name, got, tc.want)
+		}
+	}
+}
+
+// TestJSONReport_FarFutureExpiryDoesNotOverflow guards the 9999-12-31 "no
+// expiry" convention: time.Duration is int64 nanoseconds and caps at ~292
+// years, so the arithmetic has to stay in Unix seconds.
+func TestJSONReport_FarFutureExpiryDoesNotOverflow(t *testing.T) {
+	now := time.Now()
+	noExpiry := time.Date(9999, 12, 31, 23, 59, 59, 0, time.UTC)
+
+	days := daysUntil(noExpiry, now)
+	if days <= 0 {
+		t.Errorf("daysUntil = %d for a 9999 expiry; the arithmetic overflowed", days)
+	}
+}
+
+// TestJSONReport_NilInputsDoNotPanic: NewJSONReport is reachable from a command
+// that failed earlier, so it must not assume both arguments are present.
+func TestJSONReport_NilInputsDoNotPanic(t *testing.T) {
+	report := NewJSONReport("", nil, nil)
+	if report == nil {
+		t.Fatal("NewJSONReport returned nil")
+	}
+	if !report.Presentation.OK {
+		t.Error("a report with no analysis claims a presentation problem")
+	}
+	marshal(t, report)
+}


### PR DESCRIPTION
## What

`y509 validate --json` writes the whole result to stdout as JSON instead of the text report.

```console
$ y509 validate incomplete-chain.badssl.com:443 --json | jq '{trust: .trust.level, ok: .presentation.ok, findings: .presentation.findings}'
{
  "trust": "trusted",
  "ok": false,
  "findings": [
    {
      "problem": "missing issuer",
      "subject": "*.badssl.com",
      "detail": "the chain stops at a certificate that is not a CA; its issuer \"YR2\" was never sent, so a client that does not chase AIA (curl, Go, Java) cannot build a chain",
      "fetchUrls": ["http://yr2.i.lencr.org/"]
    }
  ]
}
```

## Why

The README sells `validate` as a CI gate, but the only thing a script could read was the exit code, and the exit code cannot carry the answer:

- It collapses `self-anchored` and `broken` into the same non-zero. The code takes pains to distinguish them (`TrustLevel`'s doc comment records that merging them was a past bug), and that distinction was invisible to every consumer.
- It says nothing about how the chain was *served*. `ChainFinding{Problem, Subject, Detail, FetchURLs}` — the "works in Chrome, breaks in curl" detection that is y509's differentiator against `openssl s_client` — reached only the text renderer. A script wanting it had to grep prose.

The example above is the case that makes the point: the chain is **trusted** and still mis-served, so a consumer that stops at the trust level learns nothing.

## Design

`pkg/certificate/report.go` is a translation layer, not json tags bolted onto the internal structs.

`TrustLevel` and `ChainProblem` are `iota` constants whose numeric values exist only to make `iota` work. Marshalling them directly would publish `"level": 2` as an API contract and break every consumer the moment a constant is inserted in the middle. Everything crossing the boundary is a string, a timestamp, or a bool, and the field set is chosen rather than inherited — `JSONCertificate` is not a dump of `x509.Certificate`, because every field added is a field that has to keep working.

Two more decisions worth flagging:

- **Slices are initialised empty**, so `findings` and `chain` marshal as `[]` rather than `null`. "No findings" is the common case, and ranging over a null is an unhelpful surprise in most languages.
- **`chain` is the order as presented**, not sorted. Sorting is exactly what destroys the evidence `presentation` reports on, so emitting the sorted chain would contradict the findings sitting next to it.

`daysUntil` works in Unix seconds rather than `time.Duration` for the same reason `ValidityPeriodDays` does: `time.Duration` is int64 nanoseconds and caps at ~292 years, which overflows on the `9999-12-31` no-expiry convention. There is a test for it.

## Compatibility

Additive. Exit codes, the default text output, and the TUI are unchanged — there is a test asserting `validate` without `--json` still prints prose.

## Verification

- `make lint` -> 0 issues
- `make vulncheck` -> 0 called vulnerabilities
- `go test ./...` -> all pass; 14 new tests
- `make test-coverage` -> 82.3%, over the 80% threshold
- Exercised by hand against `example.com:443` (trusted), `incomplete-chain.badssl.com:443` (trusted but mis-served) and `testdata/demo/certs.pem` (self-anchored, out of order, redundant root); stdout confirmed to parse under `jq -e` on the failure path.