### PR TITLE
fix(logger): scope the default log file to the user

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -80,8 +80,7 @@ func Execute() {
 func init() {
 	// Add flags
 	RootCmd.PersistentFlags().StringP("input", "i", "", "Input file containing certificates (default: stdin)")
-	RootCmd.PersistentFlags().String("log-file", "",
-		"Path to the log file (default "+logger.DefaultLogFile()+")")
+	RootCmd.PersistentFlags().String("log-file", "", logFileUsage())
 	RootCmd.PersistentFlags().Bool("debug", false, "Enable debug logging")
 
 	// Persistent, so `validate` and `export` can read from a live server too.
@@ -126,6 +125,13 @@ func init() {
 
 		return nil
 	}
+}
+
+func logFileUsage() string {
+	if def := logger.DefaultLogFile(); def != "" {
+		return "Path to the log file (default " + def + ")"
+	}
+	return "Path to the log file (no default without a user cache directory)"
 }
 
 // input is where a command's certificates came from.

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -80,7 +80,8 @@ func Execute() {
 func init() {
 	// Add flags
 	RootCmd.PersistentFlags().StringP("input", "i", "", "Input file containing certificates (default: stdin)")
-	RootCmd.PersistentFlags().String("log-file", "", "Path to the log file")
+	RootCmd.PersistentFlags().String("log-file", "",
+		"Path to the log file (default "+logger.DefaultLogFile()+")")
 	RootCmd.PersistentFlags().Bool("debug", false, "Enable debug logging")
 
 	// Persistent, so `validate` and `export` can read from a live server too.

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -21,63 +21,28 @@ var (
 	Log = zap.NewNop()
 )
 
-// DefaultLogFile reports where Init writes when --log-file is not given.
-//
-// A fixed name in os.TempDir() would be one world-writable path shared by every
-// account on the host: interleaved lines, a file owned by whoever ran y509
-// first, and a place to pre-plant a symlink that y509 then writes through.
+// DefaultLogFile reports where Init writes when --log-file is not given, or ""
+// when this user has no private directory to write to. os.TempDir() is not an
+// option: every account on the host shares it, and can prepare whatever y509
+// opens there.
 func DefaultLogFile() string {
-	path, _ := defaultLogFile()
-	return path
-}
-
-// defaultLogFile also reports whether the path landed in a directory other
-// users can write to.
-func defaultLogFile() (path string, shared bool) {
-	// $XDG_CACHE_HOME or ~/.cache, ~/Library/Caches, %LocalAppData%.
-	if dir, err := os.UserCacheDir(); err == nil {
-		return filepath.Join(dir, logDirName, logFileName), false
-	}
-	// Only when the environment names no home at all: a daemon, a stripped
-	// cron env. Back in the shared directory, so scope the name to the user.
-	return filepath.Join(os.TempDir(), tempLogDirName(), logFileName), true
-}
-
-func tempLogDirName() string {
-	// Getuid is -1 on Windows, where TempDir is already per-user.
-	if uid := os.Getuid(); uid >= 0 {
-		return fmt.Sprintf("%s-%d", logDirName, uid)
-	}
-	return logDirName
-}
-
-// ensureLogDir creates the log directory, readable by its owner alone.
-func ensureLogDir(dir string, shared bool) error {
-	if err := os.MkdirAll(dir, logDirPerm); err != nil {
-		return err
-	}
-	if !shared {
-		return nil
-	}
-	// MkdirAll is content with a symlink that is already in place. In the
-	// user's own cache directory that link can only be their own doing, but in
-	// the shared one it can be anybody's, pointing anywhere.
-	info, err := os.Lstat(dir)
+	dir, err := os.UserCacheDir()
 	if err != nil {
-		return err
+		return ""
 	}
-	if !info.IsDir() {
-		return fmt.Errorf("%s is not a directory", dir)
-	}
-	return nil
+	return filepath.Join(dir, logDirName, logFileName)
 }
 
 // Init initializes the logger with the specified configuration
 func Init(logFile string, debug bool) error {
 	if logFile == "" {
-		var shared bool
-		logFile, shared = defaultLogFile()
-		if err := ensureLogDir(filepath.Dir(logFile), shared); err != nil {
+		logFile = DefaultLogFile()
+		if logFile == "" {
+			// Nowhere private to log, so log nowhere.
+			Log = zap.NewNop()
+			return nil
+		}
+		if err := os.MkdirAll(filepath.Dir(logFile), logDirPerm); err != nil {
 			return fmt.Errorf("creating the log directory: %w", err)
 		}
 	}

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -11,14 +11,9 @@ import (
 )
 
 const (
-	// logFileName is the basename of the default log file.
 	logFileName = "y509.log"
-	// logDirName is the per-application directory the default log lives in.
-	logDirName = "y509"
-	// logDirPerm keeps the default log directory readable by its owner alone.
-	// The log records which files were opened and which hosts were dialled,
-	// which on a shared machine is nobody else's business.
-	logDirPerm = 0o700
+	logDirName  = "y509"
+	logDirPerm  = 0o700
 )
 
 var (
@@ -26,45 +21,63 @@ var (
 	Log = zap.NewNop()
 )
 
-// DefaultLogFile reports the path Init writes to when --log-file is not given.
+// DefaultLogFile reports where Init writes when --log-file is not given.
 //
-// It deliberately avoids a fixed name directly in os.TempDir(). /tmp is shared
-// and world-writable, so every account on a host would append to the same
-// /tmp/y509.log: interleaved lines, a file whose owner is whoever ran y509
-// first (so the next user's run fails outright), and an obvious place for
-// someone else to pre-plant a symlink that y509 then writes through.
+// A fixed name in os.TempDir() would be one world-writable path shared by every
+// account on the host: interleaved lines, a file owned by whoever ran y509
+// first, and a place to pre-plant a symlink that y509 then writes through.
 func DefaultLogFile() string {
-	// UserCacheDir is per-user by construction: $XDG_CACHE_HOME or ~/.cache on
-	// Linux, ~/Library/Caches on macOS, %LocalAppData% on Windows.
-	if dir, err := os.UserCacheDir(); err == nil {
-		return filepath.Join(dir, logDirName, logFileName)
-	}
-
-	// It only fails when the environment names no home at all -- a daemon, a
-	// stripped cron env. Fall back to os.TempDir(), still scoped so that two
-	// accounts never meet in the same file.
-	return filepath.Join(os.TempDir(), tempLogDirName(), logFileName)
+	path, _ := defaultLogFile()
+	return path
 }
 
-// tempLogDirName names the fallback directory after the current user.
+// defaultLogFile also reports whether the path landed in a directory other
+// users can write to.
+func defaultLogFile() (path string, shared bool) {
+	// $XDG_CACHE_HOME or ~/.cache, ~/Library/Caches, %LocalAppData%.
+	if dir, err := os.UserCacheDir(); err == nil {
+		return filepath.Join(dir, logDirName, logFileName), false
+	}
+	// Only when the environment names no home at all: a daemon, a stripped
+	// cron env. Back in the shared directory, so scope the name to the user.
+	return filepath.Join(os.TempDir(), tempLogDirName(), logFileName), true
+}
+
 func tempLogDirName() string {
-	// Getuid returns -1 on Windows, where TempDir is already per-user.
+	// Getuid is -1 on Windows, where TempDir is already per-user.
 	if uid := os.Getuid(); uid >= 0 {
 		return fmt.Sprintf("%s-%d", logDirName, uid)
 	}
 	return logDirName
 }
 
+// ensureLogDir creates the log directory, readable by its owner alone.
+func ensureLogDir(dir string, shared bool) error {
+	if err := os.MkdirAll(dir, logDirPerm); err != nil {
+		return err
+	}
+	if !shared {
+		return nil
+	}
+	// MkdirAll is content with a symlink that is already in place. In the
+	// user's own cache directory that link can only be their own doing, but in
+	// the shared one it can be anybody's, pointing anywhere.
+	info, err := os.Lstat(dir)
+	if err != nil {
+		return err
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("%s is not a directory", dir)
+	}
+	return nil
+}
+
 // Init initializes the logger with the specified configuration
 func Init(logFile string, debug bool) error {
 	if logFile == "" {
-		logFile = DefaultLogFile()
-
-		// The default path lives in a directory y509 owns and may have to
-		// create. 0700 is the part that matters: it is what keeps the other
-		// accounts on the host out of the log, and what stops them from
-		// planting the file before this process gets there.
-		if err := os.MkdirAll(filepath.Dir(logFile), logDirPerm); err != nil {
+		var shared bool
+		logFile, shared = defaultLogFile()
+		if err := ensureLogDir(filepath.Dir(logFile), shared); err != nil {
 			return fmt.Errorf("creating the log directory: %w", err)
 		}
 	}

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -2,6 +2,7 @@
 package logger
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -9,15 +10,63 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
+const (
+	// logFileName is the basename of the default log file.
+	logFileName = "y509.log"
+	// logDirName is the per-application directory the default log lives in.
+	logDirName = "y509"
+	// logDirPerm keeps the default log directory readable by its owner alone.
+	// The log records which files were opened and which hosts were dialled,
+	// which on a shared machine is nobody else's business.
+	logDirPerm = 0o700
+)
+
 var (
 	// Log is the global logger instance, initialized with a no-op logger by default
 	Log = zap.NewNop()
 )
 
+// DefaultLogFile reports the path Init writes to when --log-file is not given.
+//
+// It deliberately avoids a fixed name directly in os.TempDir(). /tmp is shared
+// and world-writable, so every account on a host would append to the same
+// /tmp/y509.log: interleaved lines, a file whose owner is whoever ran y509
+// first (so the next user's run fails outright), and an obvious place for
+// someone else to pre-plant a symlink that y509 then writes through.
+func DefaultLogFile() string {
+	// UserCacheDir is per-user by construction: $XDG_CACHE_HOME or ~/.cache on
+	// Linux, ~/Library/Caches on macOS, %LocalAppData% on Windows.
+	if dir, err := os.UserCacheDir(); err == nil {
+		return filepath.Join(dir, logDirName, logFileName)
+	}
+
+	// It only fails when the environment names no home at all -- a daemon, a
+	// stripped cron env. Fall back to os.TempDir(), still scoped so that two
+	// accounts never meet in the same file.
+	return filepath.Join(os.TempDir(), tempLogDirName(), logFileName)
+}
+
+// tempLogDirName names the fallback directory after the current user.
+func tempLogDirName() string {
+	// Getuid returns -1 on Windows, where TempDir is already per-user.
+	if uid := os.Getuid(); uid >= 0 {
+		return fmt.Sprintf("%s-%d", logDirName, uid)
+	}
+	return logDirName
+}
+
 // Init initializes the logger with the specified configuration
 func Init(logFile string, debug bool) error {
 	if logFile == "" {
-		logFile = filepath.Join(os.TempDir(), "y509.log")
+		logFile = DefaultLogFile()
+
+		// The default path lives in a directory y509 owns and may have to
+		// create. 0700 is the part that matters: it is what keeps the other
+		// accounts on the host out of the log, and what stops them from
+		// planting the file before this process gets there.
+		if err := os.MkdirAll(filepath.Dir(logFile), logDirPerm); err != nil {
+			return fmt.Errorf("creating the log directory: %w", err)
+		}
 	}
 
 	config := zap.NewProductionConfig()

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -74,13 +74,20 @@ func TestInitWithoutDebugDropsDebugLines(t *testing.T) {
 	}
 }
 
-// privateCacheDir points the user cache directory at a scratch directory, so a
-// test exercising the default log path never touches the real one.
-func privateCacheDir(t *testing.T) string {
+// skipOnWindows skips tests that drive os.UserCacheDir through $HOME, which
+// Windows does not read.
+func skipOnWindows(t *testing.T) {
 	t.Helper()
 	if runtime.GOOS == "windows" {
-		t.Skip("the cache directory is resolved from %LocalAppData% on Windows")
+		t.Skip("os.UserCacheDir() reads %LocalAppData% on Windows")
 	}
+}
+
+// privateCacheDir points the user cache directory at a scratch directory, so a
+// test of the default log path never touches the real one.
+func privateCacheDir(t *testing.T) string {
+	t.Helper()
+	skipOnWindows(t)
 
 	home := t.TempDir()
 	t.Setenv("HOME", home)
@@ -103,21 +110,17 @@ func TestDefaultLogFileIsUnderTheUserCacheDir(t *testing.T) {
 }
 
 func TestDefaultLogFileIsNotSharedInTempDir(t *testing.T) {
-	// No home of any kind, so the cache directory cannot be resolved and the
-	// fallback kicks in. It may live in os.TempDir(), but never as a fixed name
-	// straight in it -- that is the collision the fallback exists to avoid.
-	if runtime.GOOS == "windows" {
-		t.Skip("os.UserCacheDir() reads %LocalAppData% on Windows, not $HOME")
-	}
+	// No home of any kind, so the fallback answers instead.
+	skipOnWindows(t)
 	t.Setenv("HOME", "")
 	t.Setenv("XDG_CACHE_HOME", "")
 
 	got := DefaultLogFile()
 	if dir := filepath.Dir(got); dir == os.TempDir() {
-		t.Errorf("DefaultLogFile() = %q, which is a fixed name in the shared %s", got, os.TempDir())
+		t.Errorf("DefaultLogFile() = %q, a fixed name in the shared %s", got, os.TempDir())
 	}
 	if want := fmt.Sprintf("y509-%d", os.Getuid()); filepath.Base(filepath.Dir(got)) != want {
-		t.Errorf("DefaultLogFile() = %q, want the parent directory scoped to the user as %q", got, want)
+		t.Errorf("DefaultLogFile() = %q, want a parent directory scoped to the user as %q", got, want)
 	}
 }
 
@@ -142,6 +145,53 @@ func TestInitDefaultsToAPrivateUserDirectory(t *testing.T) {
 	}
 	if perm := info.Mode().Perm(); perm != 0o700 {
 		t.Errorf("log directory mode = %#o, want %#o so no other user can read it", perm, 0o700)
+	}
+}
+
+func TestInitRefusesASymlinkPlantedInTheSharedDirectory(t *testing.T) {
+	restoreLog(t)
+	skipOnWindows(t)
+	elsewhere := t.TempDir()
+
+	// No home, so the log falls back to the shared directory -- where another
+	// user can get there first with a link pointing at a file of their choice.
+	t.Setenv("HOME", "")
+	t.Setenv("XDG_CACHE_HOME", "")
+	t.Setenv("TMPDIR", t.TempDir())
+	if err := os.Symlink(elsewhere, filepath.Dir(DefaultLogFile())); err != nil {
+		t.Fatalf("seeding the symlink: %v", err)
+	}
+
+	if err := Init("", false); err == nil {
+		t.Error("Init() returned nil for a log directory that is a symlink")
+	}
+	if _, err := os.Stat(filepath.Join(elsewhere, "y509.log")); err == nil {
+		t.Errorf("Init() wrote through the symlink into %s", elsewhere)
+	}
+}
+
+func TestInitAllowsASymlinkedCacheDirectory(t *testing.T) {
+	restoreLog(t)
+	cache := privateCacheDir(t)
+
+	// Only the user can plant this one, and pointing a cache directory at
+	// another disk is a thing people do on purpose.
+	elsewhere := t.TempDir()
+	if err := os.MkdirAll(cache, 0o700); err != nil {
+		t.Fatalf("seeding the cache directory: %v", err)
+	}
+	if err := os.Symlink(elsewhere, filepath.Join(cache, "y509")); err != nil {
+		t.Fatalf("seeding the symlink: %v", err)
+	}
+
+	if err := Init("", false); err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+	Log.Info("through the link")
+	_ = Log.Sync()
+
+	if _, err := os.Stat(filepath.Join(elsewhere, "y509.log")); err != nil {
+		t.Errorf("expected the log at the far end of the link: %v", err)
 	}
 }
 

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -1,7 +1,6 @@
 package logger
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -74,8 +73,6 @@ func TestInitWithoutDebugDropsDebugLines(t *testing.T) {
 	}
 }
 
-// skipOnWindows skips tests that drive os.UserCacheDir through $HOME, which
-// Windows does not read.
 func skipOnWindows(t *testing.T) {
 	t.Helper()
 	if runtime.GOOS == "windows" {
@@ -83,8 +80,7 @@ func skipOnWindows(t *testing.T) {
 	}
 }
 
-// privateCacheDir points the user cache directory at a scratch directory, so a
-// test of the default log path never touches the real one.
+// privateCacheDir keeps a test of the default path off the real cache directory.
 func privateCacheDir(t *testing.T) string {
 	t.Helper()
 	skipOnWindows(t)
@@ -109,18 +105,30 @@ func TestDefaultLogFileIsUnderTheUserCacheDir(t *testing.T) {
 	}
 }
 
-func TestDefaultLogFileIsNotSharedInTempDir(t *testing.T) {
-	// No home of any kind, so the fallback answers instead.
+func TestInitWithoutAUserCacheDirWritesNothing(t *testing.T) {
+	restoreLog(t)
 	skipOnWindows(t)
+
+	tmp := t.TempDir()
 	t.Setenv("HOME", "")
 	t.Setenv("XDG_CACHE_HOME", "")
+	t.Setenv("TMPDIR", tmp)
 
-	got := DefaultLogFile()
-	if dir := filepath.Dir(got); dir == os.TempDir() {
-		t.Errorf("DefaultLogFile() = %q, a fixed name in the shared %s", got, os.TempDir())
+	if got := DefaultLogFile(); got != "" {
+		t.Errorf("DefaultLogFile() = %q, want no default", got)
 	}
-	if want := fmt.Sprintf("y509-%d", os.Getuid()); filepath.Base(filepath.Dir(got)) != want {
-		t.Errorf("DefaultLogFile() = %q, want a parent directory scoped to the user as %q", got, want)
+	if err := Init("", false); err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+	Log.Info("nowhere to go")
+	_ = Log.Sync()
+
+	entries, err := os.ReadDir(tmp)
+	if err != nil {
+		t.Fatalf("reading the temporary directory: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("Init() wrote %d entries into the shared %s", len(entries), tmp)
 	}
 }
 
@@ -145,53 +153,6 @@ func TestInitDefaultsToAPrivateUserDirectory(t *testing.T) {
 	}
 	if perm := info.Mode().Perm(); perm != 0o700 {
 		t.Errorf("log directory mode = %#o, want %#o so no other user can read it", perm, 0o700)
-	}
-}
-
-func TestInitRefusesASymlinkPlantedInTheSharedDirectory(t *testing.T) {
-	restoreLog(t)
-	skipOnWindows(t)
-	elsewhere := t.TempDir()
-
-	// No home, so the log falls back to the shared directory -- where another
-	// user can get there first with a link pointing at a file of their choice.
-	t.Setenv("HOME", "")
-	t.Setenv("XDG_CACHE_HOME", "")
-	t.Setenv("TMPDIR", t.TempDir())
-	if err := os.Symlink(elsewhere, filepath.Dir(DefaultLogFile())); err != nil {
-		t.Fatalf("seeding the symlink: %v", err)
-	}
-
-	if err := Init("", false); err == nil {
-		t.Error("Init() returned nil for a log directory that is a symlink")
-	}
-	if _, err := os.Stat(filepath.Join(elsewhere, "y509.log")); err == nil {
-		t.Errorf("Init() wrote through the symlink into %s", elsewhere)
-	}
-}
-
-func TestInitAllowsASymlinkedCacheDirectory(t *testing.T) {
-	restoreLog(t)
-	cache := privateCacheDir(t)
-
-	// Only the user can plant this one, and pointing a cache directory at
-	// another disk is a thing people do on purpose.
-	elsewhere := t.TempDir()
-	if err := os.MkdirAll(cache, 0o700); err != nil {
-		t.Fatalf("seeding the cache directory: %v", err)
-	}
-	if err := os.Symlink(elsewhere, filepath.Join(cache, "y509")); err != nil {
-		t.Fatalf("seeding the symlink: %v", err)
-	}
-
-	if err := Init("", false); err != nil {
-		t.Fatalf("Init() error = %v", err)
-	}
-	Log.Info("through the link")
-	_ = Log.Sync()
-
-	if _, err := os.Stat(filepath.Join(elsewhere, "y509.log")); err != nil {
-		t.Errorf("expected the log at the far end of the link: %v", err)
 	}
 }
 

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -1,8 +1,10 @@
 package logger
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -72,12 +74,56 @@ func TestInitWithoutDebugDropsDebugLines(t *testing.T) {
 	}
 }
 
-func TestInitDefaultsToTempDir(t *testing.T) {
+// privateCacheDir points the user cache directory at a scratch directory, so a
+// test exercising the default log path never touches the real one.
+func privateCacheDir(t *testing.T) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("the cache directory is resolved from %LocalAppData% on Windows")
+	}
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(home, ".cache"))
+
+	dir, err := os.UserCacheDir()
+	if err != nil {
+		t.Fatalf("os.UserCacheDir() error = %v", err)
+	}
+	return dir
+}
+
+func TestDefaultLogFileIsUnderTheUserCacheDir(t *testing.T) {
+	cache := privateCacheDir(t)
+
+	want := filepath.Join(cache, "y509", "y509.log")
+	if got := DefaultLogFile(); got != want {
+		t.Errorf("DefaultLogFile() = %q, want %q", got, want)
+	}
+}
+
+func TestDefaultLogFileIsNotSharedInTempDir(t *testing.T) {
+	// No home of any kind, so the cache directory cannot be resolved and the
+	// fallback kicks in. It may live in os.TempDir(), but never as a fixed name
+	// straight in it -- that is the collision the fallback exists to avoid.
+	if runtime.GOOS == "windows" {
+		t.Skip("os.UserCacheDir() reads %LocalAppData% on Windows, not $HOME")
+	}
+	t.Setenv("HOME", "")
+	t.Setenv("XDG_CACHE_HOME", "")
+
+	got := DefaultLogFile()
+	if dir := filepath.Dir(got); dir == os.TempDir() {
+		t.Errorf("DefaultLogFile() = %q, which is a fixed name in the shared %s", got, os.TempDir())
+	}
+	if want := fmt.Sprintf("y509-%d", os.Getuid()); filepath.Base(filepath.Dir(got)) != want {
+		t.Errorf("DefaultLogFile() = %q, want the parent directory scoped to the user as %q", got, want)
+	}
+}
+
+func TestInitDefaultsToAPrivateUserDirectory(t *testing.T) {
 	restoreLog(t)
-	// The default path is shared with any other y509 on the machine, so point
-	// TMPDIR somewhere private for the duration of the test.
-	tmp := t.TempDir()
-	t.Setenv("TMPDIR", tmp)
+	privateCacheDir(t)
 
 	if err := Init("", false); err != nil {
 		t.Fatalf("Init() error = %v", err)
@@ -85,8 +131,17 @@ func TestInitDefaultsToTempDir(t *testing.T) {
 	Log.Info("default path")
 	_ = Log.Sync()
 
-	if _, err := os.Stat(filepath.Join(os.TempDir(), "y509.log")); err != nil {
-		t.Errorf("expected y509.log in %s: %v", os.TempDir(), err)
+	logFile := DefaultLogFile()
+	if _, err := os.Stat(logFile); err != nil {
+		t.Fatalf("expected the log at %s: %v", logFile, err)
+	}
+
+	info, err := os.Stat(filepath.Dir(logFile))
+	if err != nil {
+		t.Fatalf("stat of the log directory: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o700 {
+		t.Errorf("log directory mode = %#o, want %#o so no other user can read it", perm, 0o700)
 	}
 }
 


### PR DESCRIPTION
Closes #78

Without `--log-file`, every account on a host wrote to the same `/tmp/y509.log`. The default is now `<user cache dir>/y509/y509.log`, in a 0700 directory.

There is no fallback into `os.TempDir()`. Scoping the name by uid still leaves the directory itself something another user can create and fill first. When no user cache directory resolves (daemon, cron, no home), y509 logs nowhere and `--log-file` names the path.
