### PR TITLE
fix(release): pin cosign-installer to v4.1.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
         uses: anchore/sbom-action/download-syft@v0
 
       - name: Install cosign (keyless signing)
-        uses: sigstore/cosign-installer@v4
+        uses: sigstore/cosign-installer@v4.1.2
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v7


### PR DESCRIPTION
`sigstore/cosign-installer` publishes moving major tags only up to `v3`, so `@v4` does not resolve. The v1.0.3 release job failed at setup with `unable to resolve action sigstore/cosign-installer@v4, unable to find version v4`.

`v4.1.2` installs cosign v3.0.6, which is what the bundle-format `signs` block from c7af4fb needs.