### PR TITLE
docs: add a security policy, and lead the README with the served-chain question

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Built with Bubble Tea](https://img.shields.io/badge/Built%20with-Bubble%20Tea-B7A0E8.svg)](https://github.com/charmbracelet/bubbletea)
 
-A TUI for analyzing and validating X.509 certificate chains. Built on the [Charm](https://charm.sh) v2 stack — [Bubble Tea](https://charm.land/bubbletea/v2), [Lip Gloss](https://charm.land/lipgloss/v2), [Bubbles](https://charm.land/bubbles/v2), and [huh](https://charm.land/huh/v2).
+A TUI for X.509 certificate chains. It verifies a chain against the system trust store, and — separately — reports how the chain was actually *served*: the missing intermediate, the redundant root, the wrong order. That second question is the one behind "works in the browser, breaks in `curl`", and the one `openssl s_client` leaves you to answer by eye.
+
+Built on the [Charm](https://charm.sh) v2 stack — [Bubble Tea](https://charm.land/bubbletea/v2), [Lip Gloss](https://charm.land/lipgloss/v2), [Bubbles](https://charm.land/bubbles/v2), and [huh](https://charm.land/huh/v2).
 
 ![y509 Demo](demo.gif?v=2)
 
@@ -14,6 +16,9 @@ A TUI for analyzing and validating X.509 certificate chains. Built on the [Charm
 # Homebrew (macOS)
 brew install kanywst/tap/y509
 
+# FreeBSD
+pkg install y509
+
 # Go 1.26+
 go install github.com/kanywst/y509/cmd/y509@latest
 ```
@@ -21,6 +26,11 @@ go install github.com/kanywst/y509/cmd/y509@latest
 Every [release](https://github.com/kanywst/y509/releases) attaches binaries for
 macOS and Linux, plus `.deb` and `.rpm` packages for Linux, with checksums,
 cosign signatures and an SBOM.
+
+On FreeBSD, y509 is [`security/y509`](https://www.freshports.org/security/y509/)
+in the ports tree, packaged and maintained there rather than here. Until the
+binary package reaches your repository, build it with
+`make -C /usr/ports/security/y509 install clean`.
 
 ## Usage
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
 # Security Policy
 
-y509 reads X.509 certificates from files, from stdin, and from whatever a remote server chooses to send during a TLS handshake. All of that is untrusted input, and `y509 validate` is meant to gate CI. Bugs in either of those are worth reporting privately.
+y509 reads X.509 certificates from files, from stdin, and from whatever a remote server chooses to send during a TLS handshake. All of that is untrusted input, and `y509 validate` is built to gate CI on its exit code.
 
 ## Supported versions
 
@@ -15,7 +15,7 @@ Fixes ship as a new release. There are no backport branches.
 
 Report privately through GitHub: **[open a draft advisory](https://github.com/kanywst/y509/security/advisories/new)**. That is the only channel; please do not open a public issue for a suspected vulnerability.
 
-Useful things to include, if you have them:
+Please include what you have of:
 
 - The version (`y509 version`) and the OS
 - The certificate, chain, or host that triggers it — a minimal PEM is ideal

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,49 @@
+# Security Policy
+
+y509 reads X.509 certificates from files, from stdin, and from whatever a remote server chooses to send during a TLS handshake. All of that is untrusted input, and `y509 validate` is meant to gate CI. Bugs in either of those are worth reporting privately.
+
+## Supported versions
+
+| Version | Supported |
+| :--- | :--- |
+| Latest release | Yes |
+| Anything older | No — upgrade first |
+
+Fixes ship as a new release. There are no backport branches.
+
+## Reporting a vulnerability
+
+Report privately through GitHub: **[open a draft advisory](https://github.com/kanywst/y509/security/advisories/new)**. That is the only channel; please do not open a public issue for a suspected vulnerability.
+
+Useful things to include, if you have them:
+
+- The version (`y509 version`) and the OS
+- The certificate, chain, or host that triggers it — a minimal PEM is ideal
+- The exact command line
+- What you expected versus what happened
+
+What to expect:
+
+- Acknowledgement within 7 days
+- An assessment of whether it is in scope within 14 days
+- A fix in a patch release, published together with a GitHub Security Advisory crediting you unless you would rather stay anonymous
+
+## Scope
+
+In scope:
+
+- A panic, hang, or unbounded allocation reached by parsing a malformed certificate or chain, including one sent by a remote server during `y509 <host>:<port>`
+- `y509 validate` exiting `0` for a chain a TLS client would reject, or exiting non-zero for one it would accept. The exit code is a contract that CI depends on
+- The TLS client doing anything beyond the handshake documented in the README
+- Writing outside the path the user asked for, via `export`, `--log-file`, or the default log destination
+- Leaking key material or certificate contents to a location more permissive than intended
+
+Out of scope, because it is the documented design:
+
+- The TUI handshake deliberately verifies nothing. `y509 example.com:443` is an inspection tool, and refusing to show you a broken chain would defeat the purpose. `validate` is the entry point that verifies
+- Reporting a chain as `self-anchored`, `broken`, or misconfigured. That is the tool working
+- Vulnerabilities in Go's standard library or in third-party dependencies. Report those to their maintainers. If y509 needs a version bump to pick up a fix, a normal issue or pull request is the right place
+
+## Downstream packagers
+
+y509 is packaged outside this repository, including the FreeBSD [`security/y509`](https://www.freshports.org/security/y509/) port and the [`kanywst/tap`](https://github.com/kanywst/homebrew-tap) Homebrew cask. Advisories are published here first; packaging bugs specific to a distribution belong with that packager.


### PR DESCRIPTION
There was no security policy and no private reporting channel. That mattered less when this was just a repo; it matters now that `security/y509` is in the FreeBSD ports tree and someone who finds a parser crash has nowhere to send it but a public issue.

The policy scopes itself to what is actually security-relevant here: a crash or hang reached from a malformed chain, including one a remote server sends; `validate` exiting `0` for a chain a TLS client would reject, since CI depends on that exit code; and writes outside the requested path via `export` or the log file. The TUI handshake verifying nothing is named as out of scope, because it is the design, and otherwise it gets filed as a flaw.

Private vulnerability reporting is now on, so the draft-advisory link in the policy works for people outside the repo. Dependabot security updates were off too, with only version updates configured in `dependabot.yml`.

Separately, the README's opening line described a category rather than a reason to pick this over the several certificate viewers that already exist. It now leads with the question `openssl s_client` leaves to the reader: whether the chain was served correctly. The repository description matches.

FreeBSD is added to the install block. The port landed on 2026-08-28, but it has not reached the `FreeBSD:14:amd64` or `FreeBSD:15:amd64` package sets yet, so the ports build is given alongside `pkg install`.
