### PR TITLE
fix(logger): do not fail the command when the default log path is unusable

### DIFF
--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -33,9 +33,16 @@ func DefaultLogFile() string {
 	return filepath.Join(dir, logDirName, logFileName)
 }
 
-// Init initializes the logger with the specified configuration
+// Init initializes the logger with the specified configuration.
+//
+// A --log-file the caller named is opened or the error is returned: they asked
+// for that file, so silently not writing it would be worse than failing. The
+// default destination is best-effort. A read-only or absent HOME is ordinary in
+// containers, in CI and inside distribution build sandboxes, and logging is a
+// side channel there -- losing it must not take the command down with it.
 func Init(logFile string, debug bool) error {
-	if logFile == "" {
+	requested := logFile != ""
+	if !requested {
 		logFile = DefaultLogFile()
 		if logFile == "" {
 			// Nowhere private to log, so log nowhere.
@@ -43,7 +50,8 @@ func Init(logFile string, debug bool) error {
 			return nil
 		}
 		if err := os.MkdirAll(filepath.Dir(logFile), logDirPerm); err != nil {
-			return fmt.Errorf("creating the log directory: %w", err)
+			Log = zap.NewNop()
+			return nil
 		}
 	}
 
@@ -55,11 +63,17 @@ func Init(logFile string, debug bool) error {
 	config.OutputPaths = []string{logFile}
 	config.ErrorOutputPaths = []string{logFile}
 
-	var err error
-	Log, err = config.Build()
+	// Build returns a nil logger alongside the error, so assign through a local
+	// rather than leaving Log nil for a caller that carries on.
+	built, err := config.Build()
 	if err != nil {
-		return err
+		if !requested {
+			Log = zap.NewNop()
+			return nil
+		}
+		return fmt.Errorf("opening the log file: %w", err)
 	}
+	Log = built
 
 	return nil
 }

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -156,6 +156,32 @@ func TestInitDefaultsToAPrivateUserDirectory(t *testing.T) {
 	}
 }
 
+// A container, a CI runner or a distribution build sandbox can hand y509 a HOME
+// it cannot write to. Logging is a side channel there, so the whole command
+// must not exit: PersistentPreRun turns any error from Init into os.Exit(1),
+// which took down every subcommand, --help and completion included.
+func TestInitSurvivesAnUncreatableDefaultDirectory(t *testing.T) {
+	restoreLog(t)
+	skipOnWindows(t)
+
+	// A cache directory whose parent is a regular file can never be created.
+	blocked := filepath.Join(t.TempDir(), "not-a-dir")
+	if err := os.WriteFile(blocked, []byte("x"), 0o600); err != nil {
+		t.Fatalf("seeding the file: %v", err)
+	}
+	t.Setenv("HOME", blocked)
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(blocked, ".cache"))
+
+	if err := Init("", false); err != nil {
+		t.Fatalf("Init() error = %v, want nil so the command still runs", err)
+	}
+	if Log == nil {
+		t.Fatal("Init() left Log nil, so the first log line panics")
+	}
+	Log.Info("nowhere to go")
+	_ = Log.Sync()
+}
+
 func TestInitReturnsErrorForUnwritablePath(t *testing.T) {
 	restoreLog(t)
 	// A path whose parent is a regular file can never be opened for writing.


### PR DESCRIPTION
Found while packaging y509 for nixpkgs: the build fails because `installShellCompletion` runs `y509 completion bash` and gets back an empty file.

`logger.Init` treated an uncreatable default log directory as fatal, and `PersistentPreRun` turns any error from it into `os.Exit(1)`. So every subcommand exited 1 with no output whenever `HOME` was read-only or absent, `version`, `--help` and `completion` included. That is the normal state inside containers, on CI runners without a home, and in distribution build sandboxes, where nix sets `HOME=/homeless-shelter`.

Before, with an unwritable home:

```console
$ HOME=/homeless-shelter y509 version
Failed to initialize logger: creating the log directory: mkdir /homeless-shelter: read-only file system
$ echo $?
1
```

`Init` already had the right behaviour one branch earlier, in the case where no user cache directory resolves at all: log nowhere and carry on. A directory that resolves but cannot be created is the same situation, so it takes the same path now, as does a log file that resolves but cannot be opened. A `--log-file` the caller named stays fatal, because they asked for that file and silently not writing it would be worse.

One thing that came out of it: `config.Build()` returns a nil logger alongside its error, so `Log, err = config.Build()` left `Log` nil. Nothing hit it before because the caller exited immediately; it would have panicked on the first log line once the error stopped exiting. The assignment goes through a local now.

The new test fails on the parent commit with `Init() error = creating the log directory: ... not a directory`. `make lint` is clean and the full suite passes. Verified against a real binary too: with `HOME` unwritable, `version`, `--help` and `completion bash` all exit 0, and `completion bash` emits its 629 lines.

This wants a v1.0.4 before the nixpkgs submission, since the package has to build from a tag.
