### PR TITLE
feat(connect): add STARTTLS for ftp, ldap and mysql

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,14 @@ cat chain.pem | y509                      # stdin
 y509 example.com:443
 y509 --connect 10.0.0.1:8443 --servername api.internal
 y509 db.example.com:5432 --starttls postgres
+y509 ldap.example.com:389 --starttls ldap
+y509 db.example.com:3306 --starttls mysql
 ```
 
 An argument naming an existing file is always read as a file; anything else is
 treated as an address. Pass `--connect` to force it. `--starttls` understands
-`smtp`, `imap` and `postgres`.
+`smtp`, `imap`, `ftp`, `ldap`, `mysql` and `postgres` (`mariadb` and
+`postgresql` are accepted as aliases).
 
 The handshake deliberately verifies nothing, because a chain that fails to
 verify is usually the reason you came. Certificates come back **in the order the

--- a/docs/index.html
+++ b/docs/index.html
@@ -1075,7 +1075,7 @@ Chain as presented:
           <span class="spec__key">net</span>
           <h3>Live handshake</h3>
           <p>TLS straight to the port, or through a STARTTLS upgrade, with SNI you control.</p>
-          <ul><li>--connect · --servername</li><li>--starttls smtp / imap / postgres</li><li>verifies nothing on purpose</li></ul>
+          <ul><li>--connect · --servername</li><li>--starttls smtp / imap / ftp / ldap / mysql / postgres</li><li>verifies nothing on purpose</li></ul>
         </div>
         <div class="spec__cell">
           <span class="spec__key">audit</span>

--- a/man/man1/y509.1
+++ b/man/man1/y509.1
@@ -66,8 +66,9 @@ Read certificates from \fIFILE\fR instead of standard input.
 SNI server name to send. Defaults to the host being connected to.
 .TP
 .BI \-\-starttls " PROTOCOL"
-Upgrade a plaintext protocol before the handshake. One of \fBsmtp\fR, \fBimap\fR
-or \fBpostgres\fR.
+Upgrade a plaintext protocol before the handshake. One of \fBsmtp\fR,
+\fBimap\fR, \fBftp\fR, \fBldap\fR, \fBmysql\fR or \fBpostgres\fR.
+\fBmariadb\fR and \fBpostgresql\fR are accepted as aliases.
 .TP
 .BI \-\-timeout " DURATION"
 Timeout for a live connection. Default 10s.

--- a/pkg/certificate/connect.go
+++ b/pkg/certificate/connect.go
@@ -2,6 +2,7 @@ package certificate
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"crypto/tls"
 	"encoding/binary"
@@ -28,7 +29,7 @@ type ConnectOptions struct {
 	// checked against. It defaults to the host part of the address.
 	ServerName string
 	// StartTLS names the application protocol to negotiate an upgrade in
-	// before the TLS handshake: smtp, imap, or postgres. Empty means the
+	// before the TLS handshake; see StartTLSProtocols. Empty means the
 	// connection is TLS from the first byte.
 	StartTLS string
 	// Timeout bounds the whole operation. Zero means DefaultConnectTimeout.
@@ -232,34 +233,40 @@ func normalizeAddress(addr string) (address, host string, err error) {
 	return net.JoinHostPort(host, port), host, nil
 }
 
-// StartTLSProtocols are the application protocols FetchChain can upgrade.
-var StartTLSProtocols = []string{"smtp", "imap", "postgres"}
+// StartTLSProtocols are the application protocols FetchChain can upgrade, in
+// the order they are offered to the user.
+var StartTLSProtocols = []string{"smtp", "imap", "ftp", "ldap", "mysql", "postgres"}
+
+// startTLSNegotiators maps every accepted spelling to its prelude. One table
+// rather than two switch statements, so the set --starttls advertises and the
+// set it can actually negotiate cannot drift apart.
+var startTLSNegotiators = map[string]func(net.Conn) error{
+	"smtp":       startTLSSMTP,
+	"imap":       startTLSIMAP,
+	"ftp":        startTLSFTP,
+	"ldap":       startTLSLDAP,
+	"mysql":      startTLSMySQL,
+	"mariadb":    startTLSMySQL,
+	"postgres":   startTLSPostgres,
+	"postgresql": startTLSPostgres,
+}
 
 // supportedStartTLS reports whether negotiateStartTLS knows the protocol.
 func supportedStartTLS(protocol string) bool {
-	switch strings.ToLower(protocol) {
-	case "smtp", "imap", "postgres", "postgresql":
-		return true
-	default:
-		return false
-	}
+	_, ok := startTLSNegotiators[strings.ToLower(protocol)]
+	return ok
 }
 
 // negotiateStartTLS performs the plaintext prelude that asks the server to
 // switch to TLS. Each protocol spells this differently, which is exactly why
 // openssl s_client needs a flag for it too.
 func negotiateStartTLS(conn net.Conn, protocol string) error {
-	switch strings.ToLower(protocol) {
-	case "smtp":
-		return startTLSSMTP(conn)
-	case "imap":
-		return startTLSIMAP(conn)
-	case "postgres", "postgresql":
-		return startTLSPostgres(conn)
-	default:
+	negotiate, ok := startTLSNegotiators[strings.ToLower(protocol)]
+	if !ok {
 		return fmt.Errorf("unsupported protocol %q (supported: %s)",
 			protocol, strings.Join(StartTLSProtocols, ", "))
 	}
+	return negotiate(conn)
 }
 
 // startTLSSMTP does the EHLO / STARTTLS exchange from RFC 3207.
@@ -268,34 +275,36 @@ func startTLSSMTP(conn net.Conn) error {
 
 	// The greeting is frequently several lines. Every one of them has to be
 	// consumed here, or the leftovers are read back as the answer to EHLO.
-	if err := expectSMTPReply(reader, "220"); err != nil {
+	if err := expectReplyCode(reader, "220"); err != nil {
 		return fmt.Errorf("greeting: %w", err)
 	}
 
 	if _, err := fmt.Fprintf(conn, "EHLO y509\r\n"); err != nil {
 		return err
 	}
-	if err := expectSMTPReply(reader, "250"); err != nil {
+	if err := expectReplyCode(reader, "250"); err != nil {
 		return fmt.Errorf("EHLO: %w", err)
 	}
 
 	if _, err := fmt.Fprintf(conn, "STARTTLS\r\n"); err != nil {
 		return err
 	}
-	if err := expectSMTPReply(reader, "220"); err != nil {
+	if err := expectReplyCode(reader, "220"); err != nil {
 		return fmt.Errorf("STARTTLS: %w", err)
 	}
 	return nil
 }
 
-// expectSMTPReply reads a complete SMTP reply and checks its status code.
+// expectReplyCode reads a complete SMTP or FTP reply and checks its status
+// code. Both protocols share the grammar, so both preludes share this reader.
 //
-// A reply may span several lines. RFC 5321 marks a continuation with a hyphen
-// in the fourth column ("250-STARTTLS") and the final line with anything else,
-// normally a space ("250 OK"). Reading only the first line leaves the rest in
-// the buffer, where it gets mistaken for the answer to the next command -- so a
-// server with a multi-line greeting broke the exchange before it began.
-func expectSMTPReply(reader *bufio.Reader, code string) error {
+// A reply may span several lines. RFC 5321 (and RFC 959 before it) marks a
+// continuation with a hyphen in the fourth column ("250-STARTTLS") and the
+// final line with anything else, normally a space ("250 OK"). Reading only the
+// first line leaves the rest in the buffer, where it gets mistaken for the
+// answer to the next command -- so a server with a multi-line greeting broke
+// the exchange before it began.
+func expectReplyCode(reader *bufio.Reader, code string) error {
 	for {
 		line, err := reader.ReadString('\n')
 		if err != nil {
@@ -374,4 +383,291 @@ func startTLSPostgres(conn net.Conn) error {
 	default:
 		return fmt.Errorf("unexpected response to SSLRequest: %q", response[0])
 	}
+}
+
+// startTLSFTP does the AUTH TLS exchange from RFC 4217. The reply grammar is
+// SMTP's, down to the hyphen continuation, so the same reader serves both.
+func startTLSFTP(conn net.Conn) error {
+	reader := bufio.NewReader(conn)
+
+	if err := expectReplyCode(reader, "220"); err != nil {
+		return fmt.Errorf("greeting: %w", err)
+	}
+
+	if _, err := fmt.Fprintf(conn, "AUTH TLS\r\n"); err != nil {
+		return err
+	}
+	// 234 is "security data exchange complete": the command is accepted and the
+	// next byte on the wire is the TLS handshake. A server without TLS answers
+	// 500 or 502, which expectReplyCode reports verbatim.
+	if err := expectReplyCode(reader, "234"); err != nil {
+		return fmt.Errorf("AUTH TLS: %w", err)
+	}
+	return nil
+}
+
+// LDAP StartTLS, RFC 4511 section 4.14. The request is an ExtendedRequest whose
+// requestName is this OID; the response is an ExtendedResponse carrying an
+// LDAP result code.
+const ldapStartTLSOID = "1.3.6.1.4.1.1466.20037"
+
+// startTLSLDAP sends the StartTLS extended operation and waits for a success
+// result. Unlike the line protocols above, LDAP is BER-encoded, so the exchange
+// is assembled and parsed byte by byte rather than read as text.
+func startTLSLDAP(conn net.Conn) error {
+	if _, err := conn.Write(ldapStartTLSRequest()); err != nil {
+		return err
+	}
+
+	reader := bufio.NewReader(conn)
+	message, err := readBERElement(reader)
+	if err != nil {
+		return fmt.Errorf("reading the response: %w", err)
+	}
+	// LDAPMessage ::= SEQUENCE { messageID, protocolOp, ... }
+	if message.tag != 0x30 {
+		return fmt.Errorf("expected an LDAPMessage SEQUENCE, got tag 0x%02x", message.tag)
+	}
+
+	body := message.value
+	// Skip the messageID INTEGER to reach the protocolOp.
+	if _, body, err = parseBERElement(body); err != nil {
+		return fmt.Errorf("reading the messageID: %w", err)
+	}
+	// ExtendedResponse ::= [APPLICATION 24], i.e. the constructed tag 0x78.
+	response, _, err := parseBERElement(body)
+	if err != nil {
+		return fmt.Errorf("reading the protocolOp: %w", err)
+	}
+	if response.tag != 0x78 {
+		return fmt.Errorf("expected an ExtendedResponse, got tag 0x%02x", response.tag)
+	}
+	// Its first field is the resultCode, an ENUMERATED. Zero is success; every
+	// other value is the server declining, and its number is the diagnosis.
+	code, _, err := parseBERElement(response.value)
+	if err != nil {
+		return fmt.Errorf("reading the resultCode: %w", err)
+	}
+	if code.tag != 0x0a || len(code.value) != 1 {
+		return fmt.Errorf("malformed resultCode in the ExtendedResponse")
+	}
+	if code.value[0] != 0 {
+		return fmt.Errorf("server refused StartTLS: LDAP result code %d", code.value[0])
+	}
+	return nil
+}
+
+// ldapStartTLSRequest builds the LDAPMessage that asks for StartTLS. Every
+// length here is short-form, because every element is far below 128 bytes.
+func ldapStartTLSRequest() []byte {
+	// [0] requestName, context-specific primitive, holding the OID as a string.
+	requestName := append([]byte{0x80, byte(len(ldapStartTLSOID))}, ldapStartTLSOID...)
+	// ExtendedRequest ::= [APPLICATION 23], the constructed tag 0x77.
+	extendedRequest := append([]byte{0x77, byte(len(requestName))}, requestName...)
+	// messageID INTEGER 1. Only one message is ever sent on this connection.
+	messageID := []byte{0x02, 0x01, 0x01}
+
+	body := append(messageID, extendedRequest...) //nolint:gocritic // deliberately a new slice
+	return append([]byte{0x30, byte(len(body))}, body...)
+}
+
+// berElement is one parsed tag-length-value triple.
+type berElement struct {
+	tag   byte
+	value []byte
+}
+
+// maxBERLength caps what readBERElement will allocate. A StartTLS response is
+// a few dozen bytes; anything near this is a wrong or hostile server, and
+// without the cap its length header alone would dictate the allocation.
+const maxBERLength = 1 << 20
+
+// readBERElement reads one definite-length BER element off the wire.
+func readBERElement(reader *bufio.Reader) (berElement, error) {
+	header := make([]byte, 2)
+	if _, err := io.ReadFull(reader, header); err != nil {
+		return berElement{}, err
+	}
+
+	length := int(header[1])
+	if length&0x80 != 0 {
+		// Long form: the low seven bits count the octets that carry the length.
+		count := length & 0x7f
+		if count == 0 || count > 4 {
+			return berElement{}, fmt.Errorf("unsupported BER length of %d octets", count)
+		}
+		octets := make([]byte, count)
+		if _, err := io.ReadFull(reader, octets); err != nil {
+			return berElement{}, err
+		}
+		length = 0
+		for _, b := range octets {
+			length = length<<8 | int(b)
+		}
+	}
+	if length > maxBERLength {
+		return berElement{}, fmt.Errorf("BER element of %d bytes is implausibly large", length)
+	}
+
+	value := make([]byte, length)
+	if _, err := io.ReadFull(reader, value); err != nil {
+		return berElement{}, err
+	}
+	return berElement{tag: header[0], value: value}, nil
+}
+
+// parseBERElement takes the first element off buf and returns it with the
+// remainder. Only the short form appears inside a StartTLS response, but the
+// long form is handled so a chatty server cannot trip the parser.
+func parseBERElement(buf []byte) (berElement, []byte, error) {
+	if len(buf) < 2 {
+		return berElement{}, nil, fmt.Errorf("truncated element")
+	}
+	tag, length, rest := buf[0], int(buf[1]), buf[2:]
+
+	if length&0x80 != 0 {
+		count := length & 0x7f
+		if count == 0 || count > 4 || len(rest) < count {
+			return berElement{}, nil, fmt.Errorf("unsupported BER length of %d octets", count)
+		}
+		length = 0
+		for _, b := range rest[:count] {
+			length = length<<8 | int(b)
+		}
+		rest = rest[count:]
+	}
+	if length > len(rest) {
+		return berElement{}, nil, fmt.Errorf("element claims %d bytes, %d remain", length, len(rest))
+	}
+	return berElement{tag: tag, value: rest[:length]}, rest[length:], nil
+}
+
+// MySQL capability flags, from the initial handshake packet. Only the two that
+// decide whether an upgrade is possible are named here.
+const (
+	mysqlClientSSL        = 0x00000800
+	mysqlClientProtocol41 = 0x00000200
+)
+
+// startTLSMySQL performs the SSLRequest half of the MySQL handshake.
+//
+// MySQL inverts the usual order: the *server* speaks first, with a handshake
+// packet advertising its capabilities, and the client answers with a truncated
+// login packet that sets CLIENT_SSL and stops before the credentials. TLS then
+// starts, and the real login is replayed inside it -- which y509 never does,
+// because it only wants the certificates.
+func startTLSMySQL(conn net.Conn) error {
+	reader := bufio.NewReader(conn)
+
+	payload, sequence, err := readMySQLPacket(reader)
+	if err != nil {
+		return fmt.Errorf("reading the server greeting: %w", err)
+	}
+	// 0xff is an ERR packet: the server refused the connection outright, most
+	// often because the host is blocked or not permitted. Its body carries the
+	// reason, and reporting that beats "malformed greeting".
+	if len(payload) > 0 && payload[0] == 0xff {
+		return fmt.Errorf("server refused the connection: %s", mysqlErrorText(payload))
+	}
+
+	capabilities, err := mysqlCapabilities(payload)
+	if err != nil {
+		return err
+	}
+	if capabilities&mysqlClientSSL == 0 {
+		return fmt.Errorf("server does not advertise CLIENT_SSL; it was built or configured without TLS")
+	}
+
+	// The SSLRequest packet continues the greeting's sequence.
+	if _, err := conn.Write(mysqlSSLRequest(sequence + 1)); err != nil {
+		return err
+	}
+	return nil
+}
+
+// readMySQLPacket reads one packet and returns its payload and sequence id.
+// Every MySQL packet is a three byte little-endian length, a sequence byte,
+// and that many bytes of payload.
+func readMySQLPacket(reader *bufio.Reader) (payload []byte, sequence byte, err error) {
+	header := make([]byte, 4)
+	if _, err := io.ReadFull(reader, header); err != nil {
+		return nil, 0, err
+	}
+	length := int(header[0]) | int(header[1])<<8 | int(header[2])<<16
+
+	payload = make([]byte, length)
+	if _, err := io.ReadFull(reader, payload); err != nil {
+		return nil, 0, err
+	}
+	return payload, header[3], nil
+}
+
+// mysqlCapabilities pulls the capability flags out of a v10 initial handshake.
+//
+// The layout up to that point is fixed: a protocol version byte, a
+// NUL-terminated server version string, a four byte connection id, eight bytes
+// of auth-plugin data, one filler byte, then the lower two capability bytes.
+// The upper two arrive later, after the character set and status flags, and
+// CLIENT_SSL lives in the lower half -- but both are read, so the flags this
+// returns are the whole set the server advertised.
+func mysqlCapabilities(payload []byte) (uint32, error) {
+	if len(payload) == 0 {
+		return 0, fmt.Errorf("empty greeting")
+	}
+	if payload[0] != 10 {
+		return 0, fmt.Errorf("unsupported MySQL protocol version %d", payload[0])
+	}
+
+	end := bytes.IndexByte(payload[1:], 0)
+	if end < 0 {
+		return 0, fmt.Errorf("unterminated server version in the greeting")
+	}
+	// Past the version string: 4 (connection id) + 8 (auth data) + 1 (filler).
+	offset := 1 + end + 1 + 13
+	if len(payload) < offset+2 {
+		return 0, fmt.Errorf("greeting truncated before the capability flags")
+	}
+	capabilities := uint32(binary.LittleEndian.Uint16(payload[offset : offset+2]))
+
+	// The upper half is optional; an old or minimal server stops here.
+	if upper := offset + 2 + 3; len(payload) >= upper+2 {
+		capabilities |= uint32(binary.LittleEndian.Uint16(payload[upper:upper+2])) << 16
+	}
+	return capabilities, nil
+}
+
+// mysqlSSLRequest builds the 32 byte SSLRequest packet: capability flags, a max
+// packet size, a character set, and 23 reserved zero bytes. It is exactly a
+// login packet with everything from the username onwards cut off.
+func mysqlSSLRequest(sequence byte) []byte {
+	const (
+		payloadLength = 32
+		maxPacketSize = 1 << 24
+		utf8mb4       = 45
+	)
+
+	packet := make([]byte, 4+payloadLength)
+	packet[0] = payloadLength
+	packet[3] = sequence
+
+	binary.LittleEndian.PutUint32(packet[4:8], mysqlClientSSL|mysqlClientProtocol41)
+	binary.LittleEndian.PutUint32(packet[8:12], maxPacketSize)
+	packet[12] = utf8mb4
+	// packet[13:36] stays zero: the reserved filler.
+	return packet
+}
+
+// mysqlErrorText renders the human-readable half of an ERR packet. The body is
+// the 0xff marker, a two byte error code, and then either the message or a
+// nine byte SQL state marker ("#HY000") followed by the message.
+func mysqlErrorText(payload []byte) string {
+	if len(payload) < 3 {
+		return "unknown error"
+	}
+	code := binary.LittleEndian.Uint16(payload[1:3])
+	message := payload[3:]
+	if len(message) > 6 && message[0] == '#' {
+		message = message[6:]
+	}
+	return fmt.Sprintf("%s (error %d)", strings.TrimSpace(string(message)), code)
 }

--- a/pkg/certificate/connect_test.go
+++ b/pkg/certificate/connect_test.go
@@ -2,6 +2,7 @@ package certificate
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
@@ -9,7 +10,9 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/binary"
 	"errors"
+	"io"
 	"math/big"
 	"net"
 	"strings"
@@ -560,5 +563,229 @@ func TestFetchChain_ContextCancelDuringStartTLS(t *testing.T) {
 	}
 	if elapsed := time.Since(start); elapsed > 5*time.Second {
 		t.Errorf("took %v; the cancellation was not honoured during STARTTLS", elapsed)
+	}
+}
+
+// TestStartTLSFTP drives the AUTH TLS exchange from RFC 4217, including the
+// multi-line greeting that most real FTP servers send.
+func TestStartTLSFTP(t *testing.T) {
+	tests := []struct {
+		name     string
+		greeting string
+		reply    string
+		wantErr  bool
+	}{
+		{
+			name:     "single line greeting",
+			greeting: "220 ready\r\n",
+			reply:    "234 AUTH TLS OK\r\n",
+		},
+		{
+			name: "multi-line greeting",
+			// A hyphen in the fourth column continues the reply. Reading only
+			// the first line would leave the rest to be misread as the answer
+			// to AUTH TLS.
+			greeting: "220-welcome to the server\r\n220-be nice\r\n220 ready\r\n",
+			reply:    "234 AUTH TLS OK\r\n",
+		},
+		{
+			name:     "server has no TLS",
+			greeting: "220 ready\r\n",
+			reply:    "500 unknown command\r\n",
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client, server := net.Pipe()
+			t.Cleanup(func() { _ = client.Close() })
+
+			go func() {
+				defer func() { _ = server.Close() }()
+				if _, err := server.Write([]byte(tt.greeting)); err != nil {
+					return
+				}
+				command, err := bufio.NewReader(server).ReadString('\n')
+				if err != nil {
+					return
+				}
+				if strings.TrimSpace(command) != "AUTH TLS" {
+					t.Errorf("expected AUTH TLS, got %q", strings.TrimSpace(command))
+				}
+				_, _ = server.Write([]byte(tt.reply))
+			}()
+
+			done := make(chan error, 1)
+			go func() { done <- startTLSFTP(client) }()
+
+			select {
+			case err := <-done:
+				if tt.wantErr && err == nil {
+					t.Error("expected an error")
+				}
+				if !tt.wantErr && err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+			case <-time.After(5 * time.Second):
+				t.Fatal("startTLSFTP hung; it did not consume the greeting correctly")
+			}
+		})
+	}
+}
+
+// TestStartTLSLDAP drives the RFC 4511 extended operation against a fake
+// server, checking both the request bytes and how a refusal is reported.
+func TestStartTLSLDAP(t *testing.T) {
+	// An ExtendedResponse carrying the given LDAP result code.
+	response := func(code byte) []byte {
+		body := []byte{
+			0x02, 0x01, 0x01, // messageID 1
+			0x78, 0x07, // [APPLICATION 24] ExtendedResponse
+			0x0a, 0x01, code, // ENUMERATED resultCode
+			0x04, 0x00, // matchedDN, empty
+			0x04, 0x00, // diagnosticMessage, empty
+		}
+		return append([]byte{0x30, byte(len(body))}, body...)
+	}
+
+	tests := []struct {
+		name    string
+		reply   []byte
+		wantErr bool
+	}{
+		{name: "server accepts", reply: response(0)},
+		// 53 is unwillingToPerform, what a server without TLS configured says.
+		{name: "server refuses", reply: response(53), wantErr: true},
+		{name: "not an ExtendedResponse", reply: []byte{0x30, 0x05, 0x02, 0x01, 0x01, 0x65, 0x00}, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client, server := net.Pipe()
+			t.Cleanup(func() { _ = client.Close() })
+
+			go func() {
+				defer func() { _ = server.Close() }()
+				request := make([]byte, len(ldapStartTLSRequest()))
+				if _, err := io.ReadFull(server, request); err != nil {
+					return
+				}
+				if !bytes.Contains(request, []byte(ldapStartTLSOID)) {
+					t.Errorf("request does not carry the StartTLS OID: %x", request)
+				}
+				if request[0] != 0x30 {
+					t.Errorf("request is not an LDAPMessage SEQUENCE: %x", request)
+				}
+				_, _ = server.Write(tt.reply)
+			}()
+
+			done := make(chan error, 1)
+			go func() { done <- startTLSLDAP(client) }()
+
+			select {
+			case err := <-done:
+				if tt.wantErr && err == nil {
+					t.Error("expected an error")
+				}
+				if !tt.wantErr && err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+			case <-time.After(5 * time.Second):
+				t.Fatal("startTLSLDAP hung")
+			}
+		})
+	}
+}
+
+// errPacket builds a MySQL ERR packet: the 0xff marker, a two byte error code,
+// and the message, which conventionally opens with a "#" SQL state marker.
+func errPacket(code uint16, message string) []byte {
+	payload := []byte{0xff, 0, 0}
+	binary.LittleEndian.PutUint16(payload[1:3], code)
+	payload = append(payload, message...)
+
+	return append([]byte{byte(len(payload)), 0, 0, 0}, payload...)
+}
+
+// TestStartTLSMySQL drives the SSLRequest half of the MySQL handshake.
+func TestStartTLSMySQL(t *testing.T) {
+	// greeting builds a v10 initial handshake packet advertising capabilities.
+	greeting := func(capabilities uint32) []byte {
+		payload := []byte{10}                      // protocol version
+		payload = append(payload, "8.0.36\x00"...) // server version
+		payload = append(payload, make([]byte, 13)...)
+		lower := make([]byte, 2)
+		binary.LittleEndian.PutUint16(lower, uint16(capabilities))
+		payload = append(payload, lower...)
+		payload = append(payload, 45, 0, 0) // charset, status flags
+		upper := make([]byte, 2)
+		binary.LittleEndian.PutUint16(upper, uint16(capabilities>>16))
+		payload = append(payload, upper...)
+
+		packet := []byte{byte(len(payload)), 0, 0, 0}
+		return append(packet, payload...)
+	}
+
+	tests := []struct {
+		name     string
+		greeting []byte
+		wantErr  bool
+	}{
+		{name: "server offers TLS", greeting: greeting(mysqlClientSSL | mysqlClientProtocol41)},
+		{name: "server built without TLS", greeting: greeting(mysqlClientProtocol41), wantErr: true},
+		// An ERR packet instead of a greeting: the reason belongs in the error.
+		{name: "connection refused", greeting: errPacket(1129, "#08S01host blocked"), wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client, server := net.Pipe()
+			t.Cleanup(func() { _ = client.Close() })
+
+			sent := make(chan []byte, 1)
+			go func() {
+				defer func() { _ = server.Close() }()
+				if _, err := server.Write(tt.greeting); err != nil {
+					return
+				}
+				request := make([]byte, 36)
+				if _, err := io.ReadFull(server, request); err != nil {
+					return
+				}
+				sent <- request
+			}()
+
+			done := make(chan error, 1)
+			go func() { done <- startTLSMySQL(client) }()
+
+			select {
+			case err := <-done:
+				if tt.wantErr {
+					if err == nil {
+						t.Error("expected an error")
+					}
+					return
+				}
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			case <-time.After(5 * time.Second):
+				t.Fatal("startTLSMySQL hung")
+			}
+
+			select {
+			case request := <-sent:
+				// 32 byte payload, sequence 1, and CLIENT_SSL set.
+				if request[0] != 32 || request[3] != 1 {
+					t.Errorf("wrong SSLRequest header: %x", request[:4])
+				}
+				if flags := binary.LittleEndian.Uint32(request[4:8]); flags&mysqlClientSSL == 0 {
+					t.Errorf("SSLRequest does not set CLIENT_SSL: %08x", flags)
+				}
+			case <-time.After(5 * time.Second):
+				t.Fatal("the server never received the SSLRequest packet")
+			}
+		})
 	}
 }


### PR DESCRIPTION
## What this changes

`--starttls` gains `ftp`, `ldap` and `mysql`, with `mariadb` and `postgresql` as aliases.

## Why

certigo upgrades six protocols to y509's three, so anyone debugging an LDAP directory or a MySQL replica had no reason to reach for this over openssl.

The two switch statements that separately decided which protocols were advertised and which could actually be negotiated are now one table, so the two sets cannot drift apart. `--starttls` help and the unsupported-protocol error already read from `StartTLSProtocols`, so both picked the new names up unchanged.

## How it was verified

`make lint` 0 issues, `make test` passes. Three table tests drive each prelude against a fake server over `net.Pipe`, covering the awkward case as well as the happy one: a multi-line FTP greeting, an LDAP refusal carrying a result code, and a MySQL ERR packet in place of a greeting.

Notes on the three:

- FTP reuses the SMTP reply reader. RFC 4217 inherits RFC 959 grammar down to the hyphen continuation, so `expectSMTPReply` became `expectReplyCode` and serves both.
- LDAP is BER, so it needed a small definite-length reader. Both parsers cap the element size, so a wrong or hostile server cannot dictate an allocation from its length header alone.
- MySQL speaks first. The prelude reads the greeting, reports an ERR packet in the server's own words rather than "malformed greeting", refuses early if `CLIENT_SSL` is absent, then sends the 32-byte SSLRequest. The real login is never replayed.

README, man page and docs site updated.

- [x] `make lint` reports 0 issues
- [x] `make test` passes
- [x] New behaviour has a test