### PR TITLE
feat(release): ship Windows binaries

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,6 +11,7 @@ builds:
     goos:
       - darwin
       - linux
+      - windows
     goarch:
       - amd64
       - arm64
@@ -20,6 +21,13 @@ builds:
 archives:
   - formats:
       - tar.gz
+    # Windows has no tar in the box before Windows 10 1803, and every Windows
+    # packaging tool (Scoop, WinGet) expects a zip. Shipping a .tar.gz there
+    # makes the download the hardest step of the install.
+    format_overrides:
+      - goos: windows
+        formats:
+          - zip
     name_template: "{{ .ProjectName }}-{{ .Version }}-{{ .Os }}-{{ .Arch }}"
     files:
       - LICENSE

--- a/README.md
+++ b/README.md
@@ -24,8 +24,13 @@ go install github.com/kanywst/y509/cmd/y509@latest
 ```
 
 Every [release](https://github.com/kanywst/y509/releases) attaches binaries for
-macOS and Linux, plus `.deb` and `.rpm` packages for Linux, with checksums,
-cosign signatures and an SBOM.
+macOS, Linux and Windows — `.tar.gz` for the first two, `.zip` for Windows —
+plus `.deb` and `.rpm` packages for Linux, with checksums, cosign signatures and
+an SBOM.
+
+On Windows, unpack the zip and put `y509.exe` on your `PATH`. Any terminal that
+supports ANSI works; Windows Terminal is the safe choice. Shell completion comes
+from `y509 completion powershell`.
 
 On FreeBSD, y509 is [`security/y509`](https://www.freshports.org/security/y509/)
 in the ports tree, packaged and maintained there rather than here. Until the


### PR DESCRIPTION
## What this changes

Releases now carry Windows binaries, amd64 and arm64, as `.zip`.

## Why

The Makefile has cross-compiled for `windows/amd64` since the beginning, but `.goreleaser.yml` never listed `windows` under `goos`, so no release has ever shipped a Windows artifact. Anyone on Windows had `go install` or nothing.

That is the wrong audience to leave out. An incomplete chain served by IIS, or a corporate MITM proxy rewriting one, is exactly the bug this tool finds.

Windows gets zip rather than tar.gz: Scoop and WinGet both expect a zip, and `tar` only reached the box in Windows 10 1803, so a `.tar.gz` would make the download the hardest step of the install.

## How it was verified

`goreleaser release --snapshot`: six binaries, two new zips, deb/rpm still Linux-only, Homebrew cask untouched.

This unblocks Scoop and WinGet, which both need a released Windows URL and hash before a manifest can exist. Neither is here: Scoop needs a new `kanywst/scoop-bucket` repo and its own token secret, WinGet needs a fork of `microsoft/winget-pkgs`.

Completion on Windows comes from `y509 completion powershell`, which cobra generates at runtime.

- [x] `make lint` reports 0 issues
- [x] `make test` passes
- [x] Nothing to test beyond the snapshot build