### PR TITLE
feat(action): add a GitHub Action that gates CI on the chain

### DIFF
--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -29,7 +29,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        # windows-latest joins this list once a release carries a Windows
+        # archive. The action installs a published release, so it cannot be
+        # tested on a platform no release has been built for yet.
+        os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v4
       - id: check

--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -1,0 +1,112 @@
+name: action
+
+# Exercises action.yml against badssl.com, which maintains one endpoint per
+# failure mode. The action installs a released binary, so this tests the action
+# itself -- the download, the checksum, the gating -- not the working tree.
+on:
+  push:
+    branches: [main]
+    paths:
+      - "action.yml"
+      - ".github/workflows/action-test.yml"
+  pull_request:
+    paths:
+      - "action.yml"
+      - ".github/workflows/action-test.yml"
+  # Re-run weekly. The endpoints are third party, and a certificate rotation
+  # there should surface here rather than in someone else's workflow.
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  healthy:
+    name: a well-served chain passes
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - id: check
+        uses: ./
+        with:
+          target: badssl.com:443
+          # Not "expiring": a third-party certificate will wander inside any
+          # threshold eventually, and that is not this workflow's business.
+          fail-on: untrusted,mis-served
+      - name: the outputs describe a healthy chain
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "${{ steps.check.outputs.trust-level }}" = "trusted"
+          test "${{ steps.check.outputs.trusted }}" = "true"
+          test "${{ steps.check.outputs.presentation-ok }}" = "true"
+          test -n "${{ steps.check.outputs.days-until-expiry }}"
+
+  mis-served:
+    name: a chain missing an intermediate fails
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # This is the case the whole tool exists for: the chain verifies in a
+      # browser and is still misconfigured, because the intermediate was never
+      # sent. The step must fail, so its failure is the assertion.
+      - id: check
+        continue-on-error: true
+        uses: ./
+        with:
+          target: incomplete-chain.badssl.com:443
+          fail-on: mis-served
+      - name: the step failed, and named the problem
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${{ steps.check.outcome }}" != "failure" ]; then
+            echo "expected the mis-served chain to fail the gate"; exit 1
+          fi
+          test "${{ steps.check.outputs.presentation-ok }}" = "false"
+          case "${{ steps.check.outputs.problems }}" in
+            *"missing issuer"*) ;;
+            *) echo "expected a missing issuer finding, got: ${{ steps.check.outputs.problems }}"; exit 1 ;;
+          esac
+
+  untrusted:
+    name: an expired chain fails
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - id: check
+        continue-on-error: true
+        uses: ./
+        with:
+          target: expired.badssl.com:443
+          fail-on: untrusted
+      - name: the step failed, and the trust level says why
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${{ steps.check.outcome }}" != "failure" ]; then
+            echo "expected the expired chain to fail the gate"; exit 1
+          fi
+          test "${{ steps.check.outputs.trusted }}" = "false"
+
+  report-only:
+    name: fail-on none never fails the job
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - id: check
+        uses: ./
+        with:
+          target: incomplete-chain.badssl.com:443
+          fail-on: none
+      - name: the finding is still reported
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "${{ steps.check.outputs.presentation-ok }}" = "false"

--- a/README.md
+++ b/README.md
@@ -156,6 +156,59 @@ y509 validate example.com:443 --json | jq '.chain[0].daysUntilExpiry < 30'
 sorting is what destroys the evidence `presentation` reports on. `level` and
 `problem` are strings, and `findings` is always an array, never `null`.
 
+### GitHub Actions
+
+The same check as a step. It downloads a release binary, verifies its checksum,
+and fails the job on whichever findings you name:
+
+```yaml
+- uses: kanywst/y509@v1
+  with:
+    target: example.com:443
+    fail-on: untrusted,mis-served,expiring
+    expiry-days: 30
+```
+
+The interesting gate is `mis-served`, which catches the chain that *verifies*
+and is still broken for `curl`, Go and Java. Nothing else in a normal CI run
+looks for it, because the exit code of every other tool says the chain is fine.
+
+| Input | Default | |
+| :--- | :--- | :--- |
+| `target` | — | host, `host:port`, or a PEM/DER path in the workspace |
+| `version` | `latest` | a release tag; pin it for a reproducible check |
+| `fail-on` | `untrusted,mis-served` | any of `untrusted`, `mis-served`, `expiring`, or `none` |
+| `expiry-days` | `30` | threshold for `expiring` |
+| `starttls` | — | `smtp`, `imap`, `ftp`, `ldap`, `mysql`, `postgres` |
+| `servername` | — | SNI name, when it differs from the host dialled |
+| `roots` | — | PEM file of extra trust anchors, for an internal PKI |
+| `no-system-roots` | `false` | trust only `roots` |
+| `summary` | `true` | write a report to the job summary |
+
+Outputs: `trust-level`, `trusted`, `presentation-ok`, `days-until-expiry`,
+`problems`, and `report` (a path to the full JSON).
+
+Anything not listed under `fail-on` is still reported, as a warning rather than
+an error, so `fail-on: none` turns the step into a monitor:
+
+```yaml
+on:
+  schedule:
+    - cron: "0 6 * * *"
+
+jobs:
+  certificates:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        host: [www.example.com, api.example.com, smtp.example.com:587]
+    steps:
+      - uses: kanywst/y509@v1
+        with:
+          target: ${{ matrix.host }}
+          fail-on: untrusted,mis-served,expiring
+```
+
 ## Keybindings
 
 |     Key     | Action                                         |

--- a/action.yml
+++ b/action.yml
@@ -140,18 +140,34 @@ runs:
         )
 
         if [ "$archive" = "zip" ]; then
-          unzip -q -o "${workdir}/${asset}" -d "$workdir"
+          # Git Bash on the Windows runners does not always carry unzip, but
+          # the bsdtar shipped with Windows reads a zip perfectly well.
+          if command -v unzip >/dev/null 2>&1; then
+            unzip -q -o "${workdir}/${asset}" -d "$workdir"
+          else
+            tar -xf "${workdir}/${asset}" -C "$workdir"
+          fi
         else
           tar -xzf "${workdir}/${asset}" -C "$workdir"
         fi
 
-        install -d "${RUNNER_TEMP}/y509-bin"
+        mkdir -p "${RUNNER_TEMP}/y509-bin"
         if [ "$os" = "windows" ]; then
-          mv "${workdir}/y509.exe" "${RUNNER_TEMP}/y509-bin/y509.exe"
+          binary="${RUNNER_TEMP}/y509-bin/y509.exe"
+          mv "${workdir}/y509.exe" "$binary"
         else
-          mv "${workdir}/y509" "${RUNNER_TEMP}/y509-bin/y509"
-          chmod +x "${RUNNER_TEMP}/y509-bin/y509"
+          binary="${RUNNER_TEMP}/y509-bin/y509"
+          mv "${workdir}/y509" "$binary"
+          chmod +x "$binary"
         fi
+
+        # The next step runs the binary by this absolute path rather than by
+        # name. GITHUB_PATH is exported as well, so a caller's own later steps
+        # can just say "y509", but the action itself does not depend on that
+        # having taken effect: a PATH that has not been rebuilt yet turns into a
+        # "command not found" whose message lands in a redirect and is never
+        # seen again.
+        echo "Y509_BIN=$binary" >> "$GITHUB_ENV"
         echo "${RUNNER_TEMP}/y509-bin" >> "$GITHUB_PATH"
 
     - name: Check the chain
@@ -167,7 +183,16 @@ runs:
         INPUT_NO_SYSTEM_ROOTS: ${{ inputs.no-system-roots }}
         INPUT_SUMMARY: ${{ inputs.summary }}
       run: |
+        # The runner supplies "bash -e", so every command that is allowed to
+        # fail is written as one: y509's exit status is the verdict, not an
+        # error, and letting -e act on it would abort the step before the
+        # report is ever read.
         set -uo pipefail
+
+        if [ ! -x "${Y509_BIN:-}" ]; then
+          echo "::error::the install step did not leave a y509 binary behind"
+          exit 1
+        fi
 
         args=(validate "$INPUT_TARGET" --json)
         [ -n "$INPUT_STARTTLS" ] && args+=(--starttls "$INPUT_STARTTLS")
@@ -176,16 +201,16 @@ runs:
         [ "$INPUT_NO_SYSTEM_ROOTS" = "true" ] && args+=(--no-system-roots)
 
         report="${RUNNER_TEMP}/y509-report.json"
+        errors="${RUNNER_TEMP}/y509-error.txt"
         # --json replaces the text report rather than adding to it, and sends
         # the failure message to stderr, so stdout parses even when the check
-        # fails. The exit status is the verdict, not an error, so it is
-        # deliberately not allowed to abort the step here.
-        y509 "${args[@]}" > "$report" 2> "${RUNNER_TEMP}/y509-error.txt"
-        status=$?
+        # fails. "|| status=$?" keeps a non-zero verdict from tripping -e.
+        status=0
+        "$Y509_BIN" "${args[@]}" > "$report" 2> "$errors" || status=$?
 
         if [ ! -s "$report" ]; then
-          echo "::error::y509 produced no report"
-          cat "${RUNNER_TEMP}/y509-error.txt" >&2 || true
+          echo "::error::y509 exited $status without producing a report"
+          cat "$errors" >&2 || true
           exit 1
         fi
 

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,260 @@
+name: "y509 certificate check"
+description: >-
+  Check a TLS certificate chain: whether it verifies, whether it was served
+  correctly, and how long it has left. Fails the job on whichever of those you
+  choose.
+author: "kanywst"
+
+branding:
+  icon: "shield"
+  color: "blue"
+
+inputs:
+  target:
+    description: >-
+      What to check: a host, a host:port, or a path to a PEM or DER file in the
+      workspace. A path that exists is read as a file; anything else is dialled.
+    required: true
+  version:
+    description: >-
+      y509 release to run, as a tag (v1.0.4) or "latest". Pin it if you want the
+      check to be reproducible.
+    required: false
+    default: "latest"
+  fail-on:
+    description: >-
+      Which findings fail the job, comma separated. "untrusted" is a chain the
+      system trust store rejects; "mis-served" is a chain that verifies but was
+      presented wrongly -- a missing intermediate, a redundant root, the wrong
+      order; "expiring" is a leaf inside expiry-days. Use "none" to report
+      without ever failing.
+    required: false
+    default: "untrusted,mis-served"
+  expiry-days:
+    description: >-
+      Days of remaining leaf validity below which "expiring" trips. Worth
+      raising as CA/Browser Forum maximum lifetimes shrink.
+    required: false
+    default: "30"
+  starttls:
+    description: >-
+      Upgrade a plaintext protocol before the handshake: smtp, imap, ftp, ldap,
+      mysql or postgres.
+    required: false
+    default: ""
+  servername:
+    description: "SNI server name to send, if it differs from the host dialled."
+    required: false
+    default: ""
+  roots:
+    description: "Path to a PEM file of additional trust anchors, for an internal PKI."
+    required: false
+    default: ""
+  no-system-roots:
+    description: >-
+      Trust only the anchors given by "roots", ignoring the system store. Set
+      this when an internal CA is the only one that should ever verify.
+    required: false
+    default: "false"
+  summary:
+    description: "Write a report to the job summary."
+    required: false
+    default: "true"
+
+outputs:
+  trust-level:
+    description: '"trusted", "self-anchored" or "broken".'
+    value: ${{ steps.check.outputs.trust-level }}
+  trusted:
+    description: '"true" when the chain verifies against the trust anchors.'
+    value: ${{ steps.check.outputs.trusted }}
+  presentation-ok:
+    description: '"true" when the chain was served correctly.'
+    value: ${{ steps.check.outputs.presentation-ok }}
+  days-until-expiry:
+    description: "Days until the leaf expires."
+    value: ${{ steps.check.outputs.days-until-expiry }}
+  problems:
+    description: "Comma separated presentation problems, empty when there are none."
+    value: ${{ steps.check.outputs.problems }}
+  report:
+    description: "Path to the full JSON report."
+    value: ${{ steps.check.outputs.report }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install y509
+      shell: bash
+      env:
+        Y509_VERSION: ${{ inputs.version }}
+        # The token is only ever spent on api.github.com to resolve a tag and
+        # to download a public release asset. It is read here rather than
+        # hardcoded so a caller can pass a different one.
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        set -euo pipefail
+
+        case "$RUNNER_OS" in
+          Linux)   os=linux;   archive=tar.gz ;;
+          macOS)   os=darwin;  archive=tar.gz ;;
+          Windows) os=windows; archive=zip ;;
+          *) echo "::error::y509 has no build for runner OS '$RUNNER_OS'"; exit 1 ;;
+        esac
+        case "$RUNNER_ARCH" in
+          X64)   arch=amd64 ;;
+          ARM64) arch=arm64 ;;
+          *) echo "::error::y509 has no build for runner architecture '$RUNNER_ARCH'"; exit 1 ;;
+        esac
+
+        tag="$Y509_VERSION"
+        if [ "$tag" = "latest" ]; then
+          tag=$(curl -fsSL -H "Authorization: Bearer $GH_TOKEN" \
+            https://api.github.com/repos/kanywst/y509/releases/latest |
+            sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p' | head -1)
+        fi
+        if [ -z "$tag" ]; then
+          echo "::error::could not resolve a y509 release tag"; exit 1
+        fi
+        version="${tag#v}"
+
+        base="https://github.com/kanywst/y509/releases/download/${tag}"
+        asset="y509-${version}-${os}-${arch}.${archive}"
+        checksums="y509-${version}-checksums.txt"
+
+        workdir="${RUNNER_TEMP}/y509-install"
+        mkdir -p "$workdir"
+        curl -fsSL -o "${workdir}/${asset}" "${base}/${asset}"
+        curl -fsSL -o "${workdir}/${checksums}" "${base}/${checksums}"
+
+        # Verify before unpacking. A release asset is fetched over the network
+        # and then executed, so an unchecked download would make this action a
+        # way into every workflow that uses it.
+        (
+          cd "$workdir"
+          if command -v sha256sum >/dev/null 2>&1; then
+            grep " ${asset}\$" "$checksums" | sha256sum -c -
+          else
+            grep " ${asset}\$" "$checksums" | shasum -a 256 -c -
+          fi
+        )
+
+        if [ "$archive" = "zip" ]; then
+          unzip -q -o "${workdir}/${asset}" -d "$workdir"
+        else
+          tar -xzf "${workdir}/${asset}" -C "$workdir"
+        fi
+
+        install -d "${RUNNER_TEMP}/y509-bin"
+        if [ "$os" = "windows" ]; then
+          mv "${workdir}/y509.exe" "${RUNNER_TEMP}/y509-bin/y509.exe"
+        else
+          mv "${workdir}/y509" "${RUNNER_TEMP}/y509-bin/y509"
+          chmod +x "${RUNNER_TEMP}/y509-bin/y509"
+        fi
+        echo "${RUNNER_TEMP}/y509-bin" >> "$GITHUB_PATH"
+
+    - name: Check the chain
+      id: check
+      shell: bash
+      env:
+        INPUT_TARGET: ${{ inputs.target }}
+        INPUT_FAIL_ON: ${{ inputs.fail-on }}
+        INPUT_EXPIRY_DAYS: ${{ inputs.expiry-days }}
+        INPUT_STARTTLS: ${{ inputs.starttls }}
+        INPUT_SERVERNAME: ${{ inputs.servername }}
+        INPUT_ROOTS: ${{ inputs.roots }}
+        INPUT_NO_SYSTEM_ROOTS: ${{ inputs.no-system-roots }}
+        INPUT_SUMMARY: ${{ inputs.summary }}
+      run: |
+        set -uo pipefail
+
+        args=(validate "$INPUT_TARGET" --json)
+        [ -n "$INPUT_STARTTLS" ] && args+=(--starttls "$INPUT_STARTTLS")
+        [ -n "$INPUT_SERVERNAME" ] && args+=(--servername "$INPUT_SERVERNAME")
+        [ -n "$INPUT_ROOTS" ] && args+=(--roots "$INPUT_ROOTS")
+        [ "$INPUT_NO_SYSTEM_ROOTS" = "true" ] && args+=(--no-system-roots)
+
+        report="${RUNNER_TEMP}/y509-report.json"
+        # --json replaces the text report rather than adding to it, and sends
+        # the failure message to stderr, so stdout parses even when the check
+        # fails. The exit status is the verdict, not an error, so it is
+        # deliberately not allowed to abort the step here.
+        y509 "${args[@]}" > "$report" 2> "${RUNNER_TEMP}/y509-error.txt"
+        status=$?
+
+        if [ ! -s "$report" ]; then
+          echo "::error::y509 produced no report"
+          cat "${RUNNER_TEMP}/y509-error.txt" >&2 || true
+          exit 1
+        fi
+
+        level=$(jq -r '.trust.level' "$report")
+        trusted=$(jq -r '.trust.trusted' "$report")
+        presentation_ok=$(jq -r '.presentation.ok' "$report")
+        days=$(jq -r '.chain[0].daysUntilExpiry // empty' "$report")
+        problems=$(jq -r '[.presentation.findings[].problem] | join(", ")' "$report")
+
+        {
+          echo "trust-level=$level"
+          echo "trusted=$trusted"
+          echo "presentation-ok=$presentation_ok"
+          echo "days-until-expiry=${days:-}"
+          echo "problems=$problems"
+          echo "report=$report"
+        } >> "$GITHUB_OUTPUT"
+
+        # "none" disables every gate; otherwise a keyword must appear in the
+        # list to fail the job. Substring matching is safe because the three
+        # keywords share no prefix.
+        fail_on=",${INPUT_FAIL_ON},"
+        wants() { [ "$INPUT_FAIL_ON" != "none" ] && [ "${fail_on#*,"$1",}" != "$fail_on" ]; }
+
+        failed=0
+
+        if [ "$trusted" != "true" ]; then
+          reason=$(jq -r '.trust.error // "the chain does not verify"' "$report")
+          if wants untrusted; then
+            echo "::error::chain is $level: $reason"
+            failed=1
+          else
+            echo "::warning::chain is $level: $reason"
+          fi
+        fi
+
+        if [ "$presentation_ok" != "true" ]; then
+          # These are the findings a browser hides and curl, Go and Java do not.
+          jq -r '.presentation.findings[] | "\(.problem): \(.subject)\n  \(.detail)"' "$report" |
+            while IFS= read -r line; do echo "  $line"; done
+          if wants mis-served; then
+            echo "::error::chain was served incorrectly: $problems"
+            failed=1
+          else
+            echo "::warning::chain was served incorrectly: $problems"
+          fi
+        fi
+
+        if [ -n "${days:-}" ] && [ "$days" -lt "$INPUT_EXPIRY_DAYS" ]; then
+          if wants expiring; then
+            echo "::error::leaf expires in $days days (threshold $INPUT_EXPIRY_DAYS)"
+            failed=1
+          else
+            echo "::warning::leaf expires in $days days (threshold $INPUT_EXPIRY_DAYS)"
+          fi
+        fi
+
+        if [ "$INPUT_SUMMARY" = "true" ]; then
+          {
+            echo "### y509: \`$INPUT_TARGET\`"
+            echo
+            echo "| Check | Result |"
+            echo "| :--- | :--- |"
+            echo "| Trust | \`$level\` |"
+            echo "| Served correctly | \`$presentation_ok\`${problems:+ — $problems} |"
+            echo "| Leaf expires in | ${days:-unknown} days |"
+          } >> "$GITHUB_STEP_SUMMARY"
+        fi
+
+        # status is reported for the record; the gates above decide the job.
+        echo "y509 validate exited $status"
+        exit $failed


### PR DESCRIPTION
## What this changes

Adds `action.yml`, so the chain check can run as a workflow step.

```yaml
- uses: kanywst/y509@v1
  with:
    target: example.com:443
    fail-on: untrusted,mis-served,expiring
```

## Why

A one-off TUI run is a tool someone tries once. A step in a workflow runs every day.

The gate worth having is `mis-served`. Every other certificate check in CI answers "does this verify", which is the question that says yes while the chain is still broken for curl, Go and Java. That is why an incomplete chain sits in production for months.

## How it was verified

`action-test.yml` drives it against badssl.com, which keeps one endpoint per failure mode. Every case was also run locally under the runner shell (`bash --noprofile --norc -e -o pipefail`) against the live endpoints first.

| Target | `fail-on` | Expect | Got |
| :--- | :--- | :--- | :--- |
| `badssl.com:443` | `untrusted,mis-served` | pass | exit 0 |
| `incomplete-chain.badssl.com:443` | `mis-served` | fail | exit 1, `problems=missing issuer` |
| `expired.badssl.com:443` | `untrusted` | fail | exit 1, `trust-level=broken` |
| `incomplete-chain.badssl.com:443` | `none` | pass, still reports | exit 0, `presentation-ok=false` |
| `incomplete-chain.badssl.com:443` | `untrusted` | **pass** | exit 0 |

The last row is the correctness one: a mis-served but trusted chain must not fail a gate that only asked about trust.

The release archive is checksum-verified before unpacking. The action fetches a binary over the network and then executes it, so an unchecked download would be a way into every workflow that uses it.

`actionlint` clean, check script `shellcheck` clean.

Windows stays out of the matrix until a release carries a Windows archive (#88). The action installs a published release, so there is nothing there to test yet.

## After merge

The README says `kanywst/y509@v1`, the Actions convention. That floating major tag does not exist yet and needs creating, then moving on each release.

- [x] `make lint` reports 0 issues
- [x] `make test` passes
- [x] New behaviour has a test