### PR TITLE
docs(install): add Scoop, and put Windows back in the action matrix

### DIFF
--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -29,10 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # windows-latest joins this list once a release carries a Windows
-        # archive. The action installs a published release, so it cannot be
-        # tested on a platform no release has been built for yet.
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v4
       - id: check

--- a/README.md
+++ b/README.md
@@ -23,14 +23,20 @@ pkg install y509
 go install github.com/kanywst/y509/cmd/y509@latest
 ```
 
+```powershell
+# Windows
+scoop bucket add kanywst https://github.com/kanywst/scoop-bucket
+scoop install kanywst/y509
+```
+
 Every [release](https://github.com/kanywst/y509/releases) attaches binaries for
 macOS, Linux and Windows — `.tar.gz` for the first two, `.zip` for Windows —
 plus `.deb` and `.rpm` packages for Linux, with checksums, cosign signatures and
 an SBOM.
 
-On Windows, unpack the zip and put `y509.exe` on your `PATH`. Any terminal that
-supports ANSI works; Windows Terminal is the safe choice. Shell completion comes
-from `y509 completion powershell`.
+On Windows, Scoop is the easy path; otherwise unpack the zip and put `y509.exe`
+on your `PATH`. Any terminal that supports ANSI works, and Windows Terminal is
+the safe choice. Shell completion comes from `y509 completion powershell`.
 
 On FreeBSD, y509 is [`security/y509`](https://www.freshports.org/security/y509/)
 in the ports tree, packaged and maintained there rather than here. Until the


### PR DESCRIPTION
v1.1.0 is the first release with Windows archives, so both things waiting on one can land.

[`kanywst/scoop-bucket`](https://github.com/kanywst/scoop-bucket) has a y509 manifest with `checkver` and `autoupdate`. README gains the two-line install. `windows-latest` goes back in the action matrix, per the comment left in #89.

A [winget submission](https://github.com/microsoft/winget-pkgs/pull/431389) is open separately.

- [x] `make lint` reports 0 issues
- [x] `make test` passes
- [x] The windows matrix job is the test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Windows support to the test coverage matrix.
  * Added Windows installation instructions using Scoop and manual ZIP extraction.
  * Documented ANSI terminal support and PowerShell completion for Windows users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->