### PR TITLE
fix(connect): bound what a hostile server can make the reader allocate

### DIFF
--- a/pkg/certificate/connect.go
+++ b/pkg/certificate/connect.go
@@ -505,7 +505,10 @@ func readBERElement(reader *bufio.Reader) (berElement, error) {
 			length = length<<8 | int(b)
 		}
 	}
-	if length > maxBERLength {
+	// The comparison is signed: a four-octet length such as 0xffffffff wraps to
+	// -1 where int is 32 bits, slips past an upper bound on its own, and panics
+	// in make below.
+	if length < 0 || length > maxBERLength {
 		return berElement{}, fmt.Errorf("BER element of %d bytes is implausibly large", length)
 	}
 
@@ -536,7 +539,7 @@ func parseBERElement(buf []byte) (berElement, []byte, error) {
 		}
 		rest = rest[count:]
 	}
-	if length > len(rest) {
+	if length < 0 || length > len(rest) {
 		return berElement{}, nil, fmt.Errorf("element claims %d bytes, %d remain", length, len(rest))
 	}
 	return berElement{tag: tag, value: rest[:length]}, rest[length:], nil
@@ -585,6 +588,11 @@ func startTLSMySQL(conn net.Conn) error {
 	return nil
 }
 
+// maxMySQLGreeting caps what readMySQLPacket will allocate. A real initial
+// handshake is a couple of hundred bytes; the header alone can ask for 16 MiB,
+// and the allocation would happen before a single byte of it arrived.
+const maxMySQLGreeting = 64 << 10
+
 // readMySQLPacket reads one packet and returns its payload and sequence id.
 // Every MySQL packet is a three byte little-endian length, a sequence byte,
 // and that many bytes of payload.
@@ -594,6 +602,9 @@ func readMySQLPacket(reader *bufio.Reader) (payload []byte, sequence byte, err e
 		return nil, 0, err
 	}
 	length := int(header[0]) | int(header[1])<<8 | int(header[2])<<16
+	if length > maxMySQLGreeting {
+		return nil, 0, fmt.Errorf("greeting of %d bytes is implausibly large", length)
+	}
 
 	payload = make([]byte, length)
 	if _, err := io.ReadFull(reader, payload); err != nil {

--- a/pkg/certificate/connect_test.go
+++ b/pkg/certificate/connect_test.go
@@ -789,3 +789,53 @@ func TestStartTLSMySQL(t *testing.T) {
 		})
 	}
 }
+
+// TestReadMySQLPacket_RejectsHugeLength checks that the length header alone
+// cannot dictate an allocation. A hostile server can claim the 16 MiB maximum
+// in four bytes and then send nothing.
+func TestReadMySQLPacket_RejectsHugeLength(t *testing.T) {
+	client, server := net.Pipe()
+	t.Cleanup(func() { _ = client.Close() })
+
+	go func() {
+		defer func() { _ = server.Close() }()
+		// Length 0xffffff, sequence 0, and no payload behind it.
+		_, _ = server.Write([]byte{0xff, 0xff, 0xff, 0})
+	}()
+
+	done := make(chan error, 1)
+	go func() {
+		_, _, err := readMySQLPacket(bufio.NewReader(client))
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected the oversized length to be refused")
+		}
+		if !strings.Contains(err.Error(), "implausibly large") {
+			t.Errorf("expected a size complaint, got: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("readMySQLPacket hung, or waited for 16 MiB that never came")
+	}
+}
+
+// TestParseBERElement_RejectsOversizedLength feeds the largest four-octet
+// length a server can claim.
+//
+// Where int is 64 bits, as on every platform this is built for, 0xffffffff is
+// simply larger than the buffer and the size check catches it. Where int is 32
+// bits it wraps to -1, slips past that check, and panics at the slice; the
+// signed guard in parseBERElement is what stops that, and this test cannot
+// reach it on a 64-bit host. It is here so the input stays covered either way.
+func TestParseBERElement_RejectsOversizedLength(t *testing.T) {
+	// Tag, long form announcing four length octets, then 0xffffffff.
+	buf := []byte{0x04, 0x84, 0xff, 0xff, 0xff, 0xff, 0x00}
+
+	_, _, err := parseBERElement(buf)
+	if err == nil {
+		t.Fatal("expected a length of 0xffffffff to be refused")
+	}
+}


### PR DESCRIPTION
Two findings from the review bots on #87. Both are reachable from `y509 <host>:<port>`, which points at servers the user has no reason to trust.

**`readMySQLPacket` sized its buffer straight from the length header.** A server can claim the 16 MiB maximum in four bytes and never send the payload, and the allocation happens first. The LDAP reader added in the same PR caps for exactly this reason and the MySQL one did not. Capped at 64 KiB; a real initial handshake is a couple of hundred bytes.

**The BER length checks were upper-bound only.** A four-octet `0xffffffff` wraps to `-1` where `int` is 32 bits, passes "not too large", and panics in `make` and at the slice.

## Verification

`TestReadMySQLPacket_RejectsHugeLength` fails without the cap (`expected a size complaint, got: EOF`) and passes with it.

The BER test cannot reach the wrap on a 64-bit host, where `0xffffffff` is just larger than the buffer and the existing check catches it. The test comment says so rather than implying otherwise. `linux/386` and `linux/arm` still build.

- [x] `make lint` reports 0 issues
- [x] `make test` passes
- [x] Both have a regression test