### PR TITLE
fix(action): normalise fail-on, and refuse an unknown keyword

### DIFF
--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -98,6 +98,48 @@ jobs:
           fi
           test "${{ steps.check.outputs.trusted }}" = "false"
 
+  spaced-list:
+    name: a fail-on list written with spaces still gates
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # "untrusted, mis-served" is the natural way to write this in YAML. It
+      # used to miss the second keyword, downgrading the gate to a warning and
+      # passing the job.
+      - id: check
+        continue-on-error: true
+        uses: ./
+        with:
+          target: incomplete-chain.badssl.com:443
+          fail-on: untrusted, mis-served
+      - name: the spaced list still failed the job
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${{ steps.check.outcome }}" != "failure" ]; then
+            echo "a fail-on list with spaces did not gate"; exit 1
+          fi
+
+  bad-keyword:
+    name: an unknown fail-on keyword is refused
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # A typo must not read as "gate nothing".
+      - id: check
+        continue-on-error: true
+        uses: ./
+        with:
+          target: badssl.com:443
+          fail-on: untrusted,mis-servd
+      - name: the typo failed the step
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${{ steps.check.outcome }}" != "failure" ]; then
+            echo "an unknown keyword was accepted"; exit 1
+          fi
+
   report-only:
     name: fail-on none never fails the job
     runs-on: ubuntu-latest

--- a/action.yml
+++ b/action.yml
@@ -230,10 +230,25 @@ runs:
         } >> "$GITHUB_OUTPUT"
 
         # "none" disables every gate; otherwise a keyword must appear in the
-        # list to fail the job. Substring matching is safe because the three
-        # keywords share no prefix.
-        fail_on=",${INPUT_FAIL_ON},"
-        wants() { [ "$INPUT_FAIL_ON" != "none" ] && [ "${fail_on#*,"$1",}" != "$fail_on" ]; }
+        # list to fail the job rather than only warn.
+        #
+        # The list is normalised first. "untrusted, mis-served" is the natural
+        # way to write this in YAML, and matching the raw string would quietly
+        # miss the second keyword: the finding would still be reported, but as
+        # a warning, and the job would pass. A gate that silently stops gating
+        # is worse than no gate.
+        # An unknown keyword is refused rather than ignored, for the same
+        # reason: a typo must not read as "gate nothing".
+        gates=""
+        for keyword in $(printf '%s' "$INPUT_FAIL_ON" | tr ',[:upper:]' ' [:lower:]'); do
+          case "$keyword" in
+            untrusted|mis-served|expiring|none) gates="${gates}${keyword}," ;;
+            *) echo "::error::unknown fail-on keyword '$keyword' (expected untrusted, mis-served, expiring or none)"; exit 1 ;;
+          esac
+        done
+        gates=",${gates}"
+
+        wants() { [ "${gates#*,"$1",}" != "$gates" ] && [ "${gates#*,none,}" = "$gates" ]; }
 
         failed=0
 


### PR DESCRIPTION
`fail-on` matched the raw input against `",keyword,"`. Written the natural way in YAML the space breaks it:

```yaml
fail-on: untrusted, mis-served   # mis-served never matched
```

The finding was still reported, but as `::warning::` instead of `::error::`, and the job passed. The input format a user is most likely to reach for silently defeated the gate, with nothing to point at why.

Now split and normalised before matching, and an unrecognised keyword is an error rather than ignored, since a typo must not read as "gate nothing".

| Input | Gates |
| :--- | :--- |
| `untrusted,mis-served` | untrusted, mis-served |
| `untrusted, mis-served` | untrusted, mis-served |
| `  untrusted ,  mis-served , expiring ` | untrusted, mis-served, expiring |
| `MIS-SERVED` | mis-served |
| `none` | nothing |
| `untrusted,typo` | step fails, names the typo |

Two workflow jobs cover the spaced list and the typo. Reported by the review bot on #89.

- [x] `make lint` reports 0 issues
- [x] `make test` passes
- [x] New behaviour has a test