### PR TITLE
docs: refresh the badssl example for the current Let's Encrypt intermediate

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,10 +106,10 @@ Trust anchor: ISRG Root X1
 
 Chain as presented:
   • missing issuer: *.badssl.com
-    the chain stops at a certificate that is not a CA; its issuer "R13" was
+    the chain stops at a certificate that is not a CA; its issuer "YR2" was
     never sent, so a client that does not chase AIA (curl, Go, Java) cannot
     build a chain
-    fetch from: http://r13.i.lencr.org/
+    fetch from: http://yr2.i.lencr.org/
 ```
 
 Note that the chain *verified* — on macOS the platform verifier fetched the
@@ -144,8 +144,8 @@ y509 validate example.com:443 --json | jq .
       {
         "problem": "missing issuer",
         "subject": "*.example.com",
-        "detail": "the chain stops at a certificate that is not a CA; its issuer \"R13\" was never sent, so a client that does not chase AIA (curl, Go, Java) cannot build a chain",
-        "fetchUrls": ["http://r13.i.lencr.org/"]
+        "detail": "the chain stops at a certificate that is not a CA; its issuer \"YR2\" was never sent, so a client that does not chase AIA (curl, Go, Java) cannot build a chain",
+        "fetchUrls": ["http://yr2.i.lencr.org/"]
       }
     ]
   },

--- a/docs/index.html
+++ b/docs/index.html
@@ -1000,10 +1000,10 @@ Trust anchor: <b>ISRG Root X1</b>
 Chain as presented:
   <span class="no">• missing issuer: *.badssl.com</span>
     the chain stops at a certificate that is not a CA;
-    its issuer <b>"R13"</b> was never sent, so a client that
+    its issuer <b>"YR2"</b> was never sent, so a client that
     does not chase AIA (curl, Go, Java) cannot build
     a chain
-    fetch from: http://r13.i.lencr.org/</pre>
+    fetch from: http://yr2.i.lencr.org/</pre>
         </div>
         <div class="annot">
           <span class="chip ok">TRUST ✅ verifies</span>
@@ -1149,7 +1149,7 @@ Chain as presented:
       {
         <span class="k">"problem"</span>: <span class="s">"missing issuer"</span>,
         <span class="k">"subject"</span>: <span class="s">"*.example.com"</span>,
-        <span class="k">"fetchUrls"</span>: [<span class="s">"http://r13.i.lencr.org/"</span>]
+        <span class="k">"fetchUrls"</span>: [<span class="s">"http://yr2.i.lencr.org/"</span>]
       }
     ]
   },


### PR DESCRIPTION
Let's Encrypt rotated `R13` out. The README transcript, the JSON sample and the landing page all named an issuer the tool no longer reports:

```text
was:  issuer "R13"  ->  http://r13.i.lencr.org/
now:  issuer "YR2"  ->  http://yr2.i.lencr.org/
```

`y509 validate incomplete-chain.badssl.com:443` is the first thing a reader runs, so a mismatch there reads as the tool being wrong.

Taken from a live run against the endpoint; the only remaining difference from real output is the 80-column wrapping in the code block, which is what a terminal does anyway.

- [x] `make lint` reports 0 issues
- [x] `make test` passes
- [x] Docs only