### PR TITLE
feat(json): report the handshake alongside the chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,9 +149,18 @@ y509 validate example.com:443 --json | jq .
       }
     ]
   },
-  "chain": [{ "index": 0, "commonName": "*.example.com", "daysUntilExpiry": 43, "…": "…" }]
+  "chain": [{ "index": 0, "commonName": "*.example.com", "daysUntilExpiry": 43, "…": "…" }],
+  "connection": {
+    "tlsVersion": "TLS 1.3",
+    "cipherSuite": "TLS_AES_128_GCM_SHA256",
+    "ocspStapled": true
+  }
 }
 ```
+
+`connection` is what the handshake revealed rather than what the certificates
+say, so it is absent entirely for a file or stdin input. Testing for the key is
+how a consumer tells a live check from an offline one.
 
 This exists because the exit code cannot carry the answer. It collapses
 `self-anchored` and `broken` into the same non-zero, so a script cannot tell an
@@ -164,6 +173,9 @@ y509 validate example.com:443 --json | jq -e '.presentation.ok'
 
 # Warn 30 days out, without parsing prose.
 y509 validate example.com:443 --json | jq '.chain[0].daysUntilExpiry < 30'
+
+# Find anything still negotiating below TLS 1.2.
+y509 validate example.com:443 --json | jq -e '.connection.tlsVersion | test("1\\.[23]$")'
 ```
 
 `chain` is in the order the certificates were **presented**, not sorted, because

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -143,6 +143,10 @@ type input struct {
 	// gives validate a hostname to check the leaf against, which is the whole
 	// question when you are looking at a live endpoint.
 	Host string
+	// Conn is the handshake the certificates arrived over, nil for a file or
+	// stdin. It carries the negotiated version, the cipher suite and whether
+	// OCSP was stapled, none of which the certificates themselves record.
+	Conn *certificate.ConnectResult
 }
 
 // loadInput decides where the certificates come from: a live server, a file, or
@@ -169,7 +173,7 @@ func loadInput(cmd *cobra.Command, args []string) (*input, error) {
 		if err != nil {
 			return nil, err
 		}
-		return &input{Certs: result.Certificates, Host: result.ServerName}, nil
+		return &input{Certs: result.Certificates, Host: result.ServerName, Conn: result}, nil
 	}
 
 	if target == "" {

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -76,7 +76,7 @@ says nothing at all about how the chain was served.`,
 			// Nothing else may go to stdout in this mode: the whole point is
 			// that the stream parses. The non-zero exit below still reports the
 			// failure, and cobra prints that to stderr.
-			if err := writeJSONReport(cmd.OutOrStdout(), source.Host, report, result); err != nil {
+			if err := writeJSONReport(cmd.OutOrStdout(), source, report, result); err != nil {
 				return err
 			}
 		} else {
@@ -111,14 +111,19 @@ says nothing at all about how the chain was served.`,
 // It is indented and newline-terminated because the overwhelmingly likely
 // consumer is a human reading a CI log or piping into jq, and neither is served
 // by one long line.
-func writeJSONReport(w io.Writer, host string, report *certificate.ChainReport, result *certificate.VerifyResult) error {
+func writeJSONReport(w io.Writer, source *input, report *certificate.ChainReport, result *certificate.VerifyResult) error {
+	out := certificate.NewJSONReport(source.Host, report, result)
+	// Nil for a file or stdin, which leaves the object out entirely rather
+	// than reporting a handshake that never happened.
+	out.Connection = certificate.NewJSONConnection(source.Conn)
+
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")
 	// Certificate subjects and SANs are attacker-controlled strings, and Go's
 	// default HTML escaping would mangle them into < sequences for no
 	// benefit outside a browser.
 	enc.SetEscapeHTML(false)
-	if err := enc.Encode(certificate.NewJSONReport(host, report, result)); err != nil {
+	if err := enc.Encode(out); err != nil {
 		return fmt.Errorf("failed to write JSON report: %w", err)
 	}
 	return nil

--- a/pkg/certificate/report.go
+++ b/pkg/certificate/report.go
@@ -1,6 +1,7 @@
 package certificate
 
 import (
+	"crypto/tls"
 	"crypto/x509"
 	"time"
 )
@@ -31,6 +32,42 @@ type JSONReport struct {
 	// server sent them, or the order they appear in a file. It is not sorted,
 	// because sorting is what destroys the evidence Presentation reports on.
 	Chain []JSONCertificate `json:"chain"`
+	// Connection describes the handshake the chain arrived over. It is absent
+	// for a file or stdin, where there was no handshake and every field would
+	// be an invention.
+	Connection *JSONConnection `json:"connection,omitempty"`
+}
+
+// JSONConnection is what the handshake itself revealed, as opposed to what the
+// certificates say.
+//
+// "Is anything still negotiating TLS 1.0" and "did stapling quietly stop
+// working" are both questions a scheduled check wants to answer, and neither is
+// visible anywhere in the chain.
+type JSONConnection struct {
+	// TLSVersion is the negotiated version, as "TLS 1.3" rather than 0x0304.
+	TLSVersion string `json:"tlsVersion"`
+	// CipherSuite is the negotiated suite by its IANA name.
+	CipherSuite string `json:"cipherSuite"`
+	// OCSPStapled reports whether the server stapled an OCSP response. It says
+	// nothing about what that response contained; y509 does no revocation
+	// checking.
+	OCSPStapled bool `json:"ocspStapled"`
+}
+
+// NewJSONConnection renders a handshake for the report, or nil when there was
+// none. Both fields cross the boundary as strings: Version and CipherSuite are
+// uint16 on the wire, and publishing those numbers would make the constant
+// values an API in exactly the way this package avoids elsewhere.
+func NewJSONConnection(result *ConnectResult) *JSONConnection {
+	if result == nil {
+		return nil
+	}
+	return &JSONConnection{
+		TLSVersion:  result.TLSVersionName(),
+		CipherSuite: tls.CipherSuiteName(result.CipherSuite),
+		OCSPStapled: result.OCSPStapled,
+	}
 }
 
 // JSONTrust is the verification outcome.

--- a/pkg/certificate/report_test.go
+++ b/pkg/certificate/report_test.go
@@ -1,6 +1,8 @@
 package certificate
 
 import (
+	"bytes"
+	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
 	"errors"
@@ -272,4 +274,54 @@ func TestJSONReport_NilInputsDoNotPanic(t *testing.T) {
 		t.Error("a report with no analysis claims a presentation problem")
 	}
 	marshal(t, report)
+}
+
+// TestNewJSONConnection checks the handshake fields cross the boundary as
+// strings, and that a chain with no handshake behind it produces nothing.
+func TestNewJSONConnection(t *testing.T) {
+	if got := NewJSONConnection(nil); got != nil {
+		t.Errorf("a file or stdin input produced a connection object: %+v", got)
+	}
+
+	conn := NewJSONConnection(&ConnectResult{
+		Version:     tls.VersionTLS13,
+		CipherSuite: tls.TLS_AES_128_GCM_SHA256,
+		OCSPStapled: true,
+	})
+	if conn == nil {
+		t.Fatal("expected a connection object for a live handshake")
+	}
+	if conn.TLSVersion != "TLS 1.3" {
+		t.Errorf("TLSVersion = %q, want %q", conn.TLSVersion, "TLS 1.3")
+	}
+	if conn.CipherSuite != "TLS_AES_128_GCM_SHA256" {
+		t.Errorf("CipherSuite = %q, want %q", conn.CipherSuite, "TLS_AES_128_GCM_SHA256")
+	}
+	if !conn.OCSPStapled {
+		t.Error("OCSPStapled = false, want true")
+	}
+}
+
+// TestJSONReport_ConnectionOmittedWithoutHandshake pins the wire format: the
+// key must be absent rather than null, so a consumer can test for its presence
+// to tell a live check from a file one.
+func TestJSONReport_ConnectionOmittedWithoutHandshake(t *testing.T) {
+	report := NewJSONReport("", nil, &VerifyResult{Level: TrustAnchored})
+
+	encoded, err := json.Marshal(report)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(encoded, []byte(`"connection"`)) {
+		t.Errorf("connection present with no handshake: %s", encoded)
+	}
+
+	report.Connection = NewJSONConnection(&ConnectResult{Version: tls.VersionTLS12})
+	encoded, err = json.Marshal(report)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(encoded, []byte(`"tlsVersion":"TLS 1.2"`)) {
+		t.Errorf("connection missing or wrong after a handshake: %s", encoded)
+	}
 }


### PR DESCRIPTION
Closes #92.

`FetchChain` already learned the negotiated version, the cipher suite and whether OCSP was stapled, then threw all three away at the command boundary. `TLSVersionName` had no caller outside its own test.

```json
"connection": {
  "tlsVersion": "TLS 1.3",
  "cipherSuite": "TLS_AES_128_GCM_SHA256",
  "ocspStapled": true
}
```

These are the facts a scheduled check wants and the certificates do not carry. "Is anything still negotiating TLS 1.0" and "did stapling quietly stop working" were both unanswerable from `--json` before.

Both fields cross as strings. `Version` and `CipherSuite` are `uint16`, and publishing those numbers would make the constant values an API in exactly the way `report.go` avoids for `TrustLevel` and `ChainProblem`.

The object is **omitted**, not null, for a file or stdin input. Testing for the key is how a consumer tells a live check from an offline one, and a null would have meant inventing a handshake that never happened.

## Verification

Against a live endpoint and a file:

```text
$ y509 validate badssl.com:443 --json | jq .connection
{ "tlsVersion": "TLS 1.2", "cipherSuite": "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256", "ocspStapled": false }

$ y509 validate testdata/demo/certs.pem --json | jq "has(\"connection\")"
false
```

The new README example is run rather than assumed:

```text
$ y509 validate badssl.com:443 --json | jq -e ".connection.tlsVersion | test(\"1\\\\.[23]$\")"
true
```

- [x] `make lint` reports 0 issues
- [x] `make test` passes
- [x] New behaviour has a test