### PR TITLE
feat(connect): add STARTTLS for nntp and lmtp

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ y509 db.example.com:3306 --starttls mysql
 
 An argument naming an existing file is always read as a file; anything else is
 treated as an address. Pass `--connect` to force it. `--starttls` understands
-`smtp`, `imap`, `ftp`, `ldap`, `mysql` and `postgres` (`mariadb` and
-`postgresql` are accepted as aliases).
+`smtp`, `lmtp`, `imap`, `nntp`, `ftp`, `ldap`, `mysql` and `postgres`
+(`mariadb` and `postgresql` are accepted as aliases).
 
 The handshake deliberately verifies nothing, because a chain that fails to
 verify is usually the reason you came. Certificates come back **in the order the

--- a/docs/index.html
+++ b/docs/index.html
@@ -1057,7 +1057,7 @@ Chain as presented:
 <span class="c"># a live server</span>
 <span class="p">$</span> <b>y509 example.com:443</b>
 
-<span class="c"># ...behind STARTTLS (smtp, imap, ftp, ldap, mysql, postgres)</span>
+<span class="c"># ...behind STARTTLS (smtp, lmtp, imap, nntp, ftp, ldap, mysql, postgres)</span>
 <span class="p">$</span> <b>y509 smtp.example.com:587 --starttls smtp</b>
 
 <span class="c"># an internal host with a different SNI</span>
@@ -1079,7 +1079,7 @@ Chain as presented:
           <span class="spec__key">net</span>
           <h3>Live handshake</h3>
           <p>TLS straight to the port, or through a STARTTLS upgrade, with SNI you control.</p>
-          <ul><li>--connect · --servername</li><li>--starttls smtp / imap / ftp / ldap / mysql / postgres</li><li>verifies nothing on purpose</li></ul>
+          <ul><li>--connect · --servername</li><li>--starttls smtp / lmtp / imap / nntp / ftp / ldap / mysql / postgres</li><li>verifies nothing on purpose</li></ul>
         </div>
         <div class="spec__cell">
           <span class="spec__key">audit</span>

--- a/man/man1/y509.1
+++ b/man/man1/y509.1
@@ -67,7 +67,8 @@ SNI server name to send. Defaults to the host being connected to.
 .TP
 .BI \-\-starttls " PROTOCOL"
 Upgrade a plaintext protocol before the handshake. One of \fBsmtp\fR,
-\fBimap\fR, \fBftp\fR, \fBldap\fR, \fBmysql\fR or \fBpostgres\fR.
+\fBlmtp\fR, \fBimap\fR, \fBnntp\fR, \fBftp\fR, \fBldap\fR, \fBmysql\fR or
+\fBpostgres\fR.
 \fBmariadb\fR and \fBpostgresql\fR are accepted as aliases.
 .TP
 .BI \-\-timeout " DURATION"

--- a/pkg/certificate/connect.go
+++ b/pkg/certificate/connect.go
@@ -235,14 +235,16 @@ func normalizeAddress(addr string) (address, host string, err error) {
 
 // StartTLSProtocols are the application protocols FetchChain can upgrade, in
 // the order they are offered to the user.
-var StartTLSProtocols = []string{"smtp", "imap", "ftp", "ldap", "mysql", "postgres"}
+var StartTLSProtocols = []string{"smtp", "lmtp", "imap", "nntp", "ftp", "ldap", "mysql", "postgres"}
 
 // startTLSNegotiators maps every accepted spelling to its prelude. One table
 // rather than two switch statements, so the set --starttls advertises and the
 // set it can actually negotiate cannot drift apart.
 var startTLSNegotiators = map[string]func(net.Conn) error{
 	"smtp":       startTLSSMTP,
+	"lmtp":       startTLSLMTP,
 	"imap":       startTLSIMAP,
+	"nntp":       startTLSNNTP,
 	"ftp":        startTLSFTP,
 	"ldap":       startTLSLDAP,
 	"mysql":      startTLSMySQL,
@@ -271,6 +273,19 @@ func negotiateStartTLS(conn net.Conn, protocol string) error {
 
 // startTLSSMTP does the EHLO / STARTTLS exchange from RFC 3207.
 func startTLSSMTP(conn net.Conn) error {
+	return startTLSSMTPLike(conn, "EHLO")
+}
+
+// startTLSLMTP does the same exchange for LMTP, RFC 2033, which differs from
+// SMTP only in greeting with LHLO. A server that speaks LMTP refuses EHLO
+// outright, so the verb has to be right rather than merely close.
+func startTLSLMTP(conn net.Conn) error {
+	return startTLSSMTPLike(conn, "LHLO")
+}
+
+// startTLSSMTPLike performs the SMTP-shaped prelude with the given greeting
+// verb.
+func startTLSSMTPLike(conn net.Conn, greeting string) error {
 	reader := bufio.NewReader(conn)
 
 	// The greeting is frequently several lines. Every one of them has to be
@@ -279,11 +294,11 @@ func startTLSSMTP(conn net.Conn) error {
 		return fmt.Errorf("greeting: %w", err)
 	}
 
-	if _, err := fmt.Fprintf(conn, "EHLO y509\r\n"); err != nil {
+	if _, err := fmt.Fprintf(conn, "%s y509\r\n", greeting); err != nil {
 		return err
 	}
 	if err := expectReplyCode(reader, "250"); err != nil {
-		return fmt.Errorf("EHLO: %w", err)
+		return fmt.Errorf("%s: %w", greeting, err)
 	}
 
 	if _, err := fmt.Fprintf(conn, "STARTTLS\r\n"); err != nil {
@@ -295,8 +310,33 @@ func startTLSSMTP(conn net.Conn) error {
 	return nil
 }
 
-// expectReplyCode reads a complete SMTP or FTP reply and checks its status
-// code. Both protocols share the grammar, so both preludes share this reader.
+// startTLSNNTP does the STARTTLS exchange from RFC 4642.
+//
+// The greeting is 200 when posting is allowed and 201 when the server is read
+// only. Both are a working connection, and accepting only 200 would turn every
+// read-only news server into a spurious failure.
+func startTLSNNTP(conn net.Conn) error {
+	reader := bufio.NewReader(conn)
+
+	if err := expectReplyCode(reader, "200", "201"); err != nil {
+		return fmt.Errorf("greeting: %w", err)
+	}
+
+	if _, err := fmt.Fprintf(conn, "STARTTLS\r\n"); err != nil {
+		return err
+	}
+	// 382 is "continue with TLS negotiation". A server that already has TLS on
+	// the connection answers 502, and one built without it answers 580.
+	if err := expectReplyCode(reader, "382"); err != nil {
+		return fmt.Errorf("STARTTLS: %w", err)
+	}
+	return nil
+}
+
+// expectReplyCode reads a complete reply and checks its status code against the
+// ones given. SMTP, LMTP, FTP and NNTP share the grammar, so they share this
+// reader; more than one code is accepted because an NNTP greeting is 200 or 201
+// depending on whether posting is allowed, and both are a working connection.
 //
 // A reply may span several lines. RFC 5321 (and RFC 959 before it) marks a
 // continuation with a hyphen in the fourth column ("250-STARTTLS") and the
@@ -304,14 +344,24 @@ func startTLSSMTP(conn net.Conn) error {
 // first line leaves the rest in the buffer, where it gets mistaken for the
 // answer to the next command -- so a server with a multi-line greeting broke
 // the exchange before it began.
-func expectReplyCode(reader *bufio.Reader, code string) error {
+func expectReplyCode(reader *bufio.Reader, codes ...string) error {
+	accepts := func(line string) bool {
+		for _, code := range codes {
+			if strings.HasPrefix(line, code) {
+				return true
+			}
+		}
+		return false
+	}
+
 	for {
 		line, err := reader.ReadString('\n')
 		if err != nil {
 			return err
 		}
-		if !strings.HasPrefix(line, code) {
-			return fmt.Errorf("expected %s, got: %s", code, strings.TrimSpace(line))
+		if !accepts(line) {
+			return fmt.Errorf("expected %s, got: %s",
+				strings.Join(codes, " or "), strings.TrimSpace(line))
 		}
 		// Anything but a hyphen in column four ends the reply. Testing for a
 		// space instead would hang on a bare "250\r\n", which is legal.

--- a/pkg/certificate/connect_test.go
+++ b/pkg/certificate/connect_test.go
@@ -839,3 +839,120 @@ func TestParseBERElement_RejectsOversizedLength(t *testing.T) {
 		t.Fatal("expected a length of 0xffffffff to be refused")
 	}
 }
+
+// TestStartTLSNNTP covers RFC 4642, including the read-only greeting that a
+// 200-only check would reject.
+func TestStartTLSNNTP(t *testing.T) {
+	tests := []struct {
+		name     string
+		greeting string
+		reply    string
+		wantErr  bool
+	}{
+		{
+			name:     "posting allowed",
+			greeting: "200 news.example.com InterNetNews ready\r\n",
+			reply:    "382 Continue with TLS negotiation\r\n",
+		},
+		{
+			// 201 is a working server that will not accept posts. Treating only
+			// 200 as a greeting would fail on every read-only news server.
+			name:     "read only server",
+			greeting: "201 news.example.com InterNetNews (no posting)\r\n",
+			reply:    "382 Continue with TLS negotiation\r\n",
+		},
+		{
+			name:     "server without TLS",
+			greeting: "200 news.example.com ready\r\n",
+			reply:    "580 Can not initiate TLS negotiation\r\n",
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client, server := net.Pipe()
+			t.Cleanup(func() { _ = client.Close() })
+
+			go func() {
+				defer func() { _ = server.Close() }()
+				if _, err := server.Write([]byte(tt.greeting)); err != nil {
+					return
+				}
+				command, err := bufio.NewReader(server).ReadString('\n')
+				if err != nil {
+					return
+				}
+				if strings.TrimSpace(command) != "STARTTLS" {
+					t.Errorf("expected STARTTLS, got %q", strings.TrimSpace(command))
+				}
+				_, _ = server.Write([]byte(tt.reply))
+			}()
+
+			done := make(chan error, 1)
+			go func() { done <- startTLSNNTP(client) }()
+
+			select {
+			case err := <-done:
+				if tt.wantErr && err == nil {
+					t.Error("expected an error")
+				}
+				if !tt.wantErr && err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+			case <-time.After(5 * time.Second):
+				t.Fatal("startTLSNNTP hung")
+			}
+		})
+	}
+}
+
+// TestStartTLSLMTP checks the prelude greets with LHLO rather than EHLO. A
+// server speaking LMTP refuses EHLO outright, so the verb has to be exact.
+func TestStartTLSLMTP(t *testing.T) {
+	client, server := net.Pipe()
+	t.Cleanup(func() { _ = client.Close() })
+
+	greeted := make(chan string, 1)
+	go func() {
+		defer func() { _ = server.Close() }()
+		// Multi-line, as a real LMTP greeting is.
+		if _, err := server.Write([]byte("220-lmtp.example.com\r\n220 ready\r\n")); err != nil {
+			return
+		}
+		reader := bufio.NewReader(server)
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			return
+		}
+		greeted <- strings.Fields(strings.TrimSpace(line))[0]
+		if _, err := server.Write([]byte("250-lmtp.example.com\r\n250 STARTTLS\r\n")); err != nil {
+			return
+		}
+		if _, err := reader.ReadString('\n'); err != nil {
+			return
+		}
+		_, _ = server.Write([]byte("220 go ahead\r\n"))
+	}()
+
+	done := make(chan error, 1)
+	go func() { done <- startTLSLMTP(client) }()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("startTLSLMTP hung")
+	}
+
+	select {
+	case verb := <-greeted:
+		if verb != "LHLO" {
+			t.Errorf("greeted with %q, want LHLO", verb)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("the server never saw a greeting")
+	}
+}


### PR DESCRIPTION
Closes #93. `--starttls` now covers eight protocols.

**NNTP** (RFC 4642) greets with `200` when posting is allowed and `201` when the server is read only. Both are a working connection, so `expectReplyCode` takes the set of acceptable codes rather than one. Accepting only `200` would have turned every read-only news server into a spurious failure, which is the awkward case the issue asked to cover.

**LMTP** (RFC 2033) is SMTP with `LHLO` in place of `EHLO`, and a server speaking LMTP refuses `EHLO` outright, so the verb has to be exact rather than close. The two preludes now share one function that takes the greeting verb instead of being copied.

`--starttls` help and the unsupported-protocol error read from `StartTLSProtocols`, so both picked the new names up with no edit:

```text
--starttls string   Upgrade a plaintext protocol first: smtp, lmtp, imap, nntp, ftp, ldap, mysql, postgres
```

## Verification

Four new cases over `net.Pipe`, covering the awkward paths rather than only the happy ones: an NNTP `201` read-only greeting, an NNTP `580` refusal, and an LMTP exchange that asserts the greeting verb was `LHLO` and that a multi-line `220-` greeting is consumed correctly.

README, man page and the docs site updated.

- [x] `make lint` reports 0 issues
- [x] `make test` passes
- [x] New behaviour has a test