### PR TITLE
fix(release): do not re-run the release when the v1 tag moves

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,14 @@ name: Release
 on:
   push:
     tags:
-      - 'v*'
+      # Only real version tags. The bare 'v1' that the GitHub Action points at
+      # is moved on every release, and 'v*' matched it: goreleaser then ran a
+      # second time against the same commit, rebuilt with a new timestamp, and
+      # replaced the artifacts of the release it had just published. The
+      # cosign-signed checksums were replaced along with them, so anyone who
+      # had already recorded a hash saw it stop matching.
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+-*'
 
 permissions:
   contents: write


### PR DESCRIPTION
The workflow triggered on `v*`, which matches the bare `v1` tag the GitHub Action points at.

Moving `v1` onto a release commit ran goreleaser a second time against that same commit. It rebuilt with a fresh timestamp in `ldflags`, produced different bytes, and with `replace_existing_artifacts: true` **overwrote the archives of the release it had just published**. The cosign-signed checksums were replaced along with them.

Evidence from v1.2.0:

```text
10:51  release run for v1.2.0
10:53  release run for v1        <- same commit, rebuilds
10:56  v1.2.0 assets updated     <- second run wins
```

A hash read between those two runs stopped matching afterwards. That is how the Scoop manifest ended up with `47575f09...` when the published archive hashes to `30ca9ea9...`.

The consequence worth naming: anyone who had recorded a checksum, or verified a signature, would see it break for no visible reason. Release artifacts are meant to be immutable.

Now only real version tags trigger a release. `v1` no longer matches; `v1.2.0` and `v2.0.0-rc1` still do.

- [x] `actionlint` clean
- [x] `make lint` reports 0 issues
- [x] `make test` passes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue that could cause a release to be published twice for the same commit.
  - Release artifacts and signed checksums are now protected from being unintentionally replaced by a duplicate release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->