### PR TITLE
feat(model): show how the chain was presented in the TUI

### DIFF
--- a/internal/model/findings_test.go
+++ b/internal/model/findings_test.go
@@ -1,0 +1,171 @@
+package model
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kanywst/y509/pkg/certificate"
+)
+
+// testChain builds a real three-level chain -- root CA, intermediate CA, leaf --
+// so the findings under test are the ones AnalyzeChain actually produces rather
+// than a hand-written fixture. createTestCertificates cannot be used here: it
+// returns unrelated self-signed certificates, which is itself a finding.
+func testChain(t *testing.T) (leaf, intermediate, root *certificate.Info) {
+	t.Helper()
+
+	sign := func(template, parent *x509.Certificate, parentKey *rsa.PrivateKey) (*x509.Certificate, *rsa.PrivateKey) {
+		key, err := rsa.GenerateKey(rand.Reader, 2048)
+		if err != nil {
+			t.Fatalf("generate key: %v", err)
+		}
+		signer, signerKey := parent, parentKey
+		if signer == nil {
+			signer, signerKey = template, key // self-signed
+		}
+		der, err := x509.CreateCertificate(rand.Reader, template, signer, &key.PublicKey, signerKey)
+		if err != nil {
+			t.Fatalf("create certificate %q: %v", template.Subject.CommonName, err)
+		}
+		cert, err := x509.ParseCertificate(der)
+		if err != nil {
+			t.Fatalf("parse certificate %q: %v", template.Subject.CommonName, err)
+		}
+		return cert, key
+	}
+
+	ca := func(cn string, serial int64) *x509.Certificate {
+		return &x509.Certificate{
+			SerialNumber:          big.NewInt(serial),
+			Subject:               pkix.Name{CommonName: cn},
+			NotBefore:             time.Now().Add(-time.Hour),
+			NotAfter:              time.Now().Add(24 * time.Hour),
+			KeyUsage:              x509.KeyUsageCertSign,
+			BasicConstraintsValid: true,
+			IsCA:                  true,
+		}
+	}
+
+	rootCert, rootKey := sign(ca("Test Root CA", 1), nil, nil)
+	intCert, intKey := sign(ca("Test Intermediate CA", 2), rootCert, rootKey)
+	leafCert, _ := sign(&x509.Certificate{
+		SerialNumber:          big.NewInt(3),
+		Subject:               pkix.Name{CommonName: "leaf.example.com"},
+		DNSNames:              []string{"leaf.example.com"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+	}, intCert, intKey)
+
+	return &certificate.Info{Certificate: leafCert},
+		&certificate.Info{Certificate: intCert},
+		&certificate.Info{Certificate: rootCert}
+}
+
+func TestRenderFindings(t *testing.T) {
+	leaf, intermediate, root := testChain(t)
+	cfg := loadTestConfig(t)
+
+	tests := []struct {
+		name     string
+		certs    []*certificate.Info
+		contains []string
+		absent   []string
+	}{
+		{
+			name:     "a correctly presented chain reports no problem",
+			certs:    []*certificate.Info{leaf, intermediate},
+			contains: []string{"Presented correctly"},
+			absent:   []string{"problem"},
+		},
+		{
+			name:     "a chain sent root-first is reported out of order",
+			certs:    []*certificate.Info{intermediate, leaf},
+			contains: []string{"1 problem", "out of order"},
+		},
+		{
+			name:     "a root included in the chain is reported as redundant",
+			certs:    []*certificate.Info{leaf, intermediate, root},
+			contains: []string{"redundant root", "Test Root CA"},
+		},
+		{
+			name:     "a leaf whose issuer was never sent is reported",
+			certs:    []*certificate.Info{leaf},
+			contains: []string{"missing issuer", "leaf.example.com"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := *NewModel(tt.certs, cfg)
+			got := m.renderFindings()
+
+			for _, want := range tt.contains {
+				if !strings.Contains(got, want) {
+					t.Errorf("findings tab does not mention %q:\n%s", want, got)
+				}
+			}
+			for _, unwanted := range tt.absent {
+				if strings.Contains(got, unwanted) {
+					t.Errorf("findings tab unexpectedly mentions %q:\n%s", unwanted, got)
+				}
+			}
+		})
+	}
+}
+
+// TestRenderFindingsAnalyzesBeforeSorting is the invariant the whole tab rests
+// on. The list sorts the chain before drawing it, so if the report were built
+// from the sorted slice an out-of-order chain would look perfect -- which is the
+// bug the tab exists to surface.
+func TestRenderFindingsAnalyzesBeforeSorting(t *testing.T) {
+	leaf, intermediate, _ := testChain(t)
+
+	m := *NewModel([]*certificate.Info{intermediate, leaf}, loadTestConfig(t))
+
+	if !strings.Contains(m.renderFindings(), "out of order") {
+		t.Fatalf("out-of-order chain reported clean; the report was built after sorting:\n%s", m.renderFindings())
+	}
+
+	// The list itself is still sorted leaf-first: the fix must not have been to
+	// stop sorting.
+	if cn := m.allCertificates[0].Certificate.Subject.CommonName; cn != "leaf.example.com" {
+		t.Errorf("list is no longer sorted leaf-first, first row is %q", cn)
+	}
+}
+
+func TestRenderFindingsWithoutCertificates(t *testing.T) {
+	m := *NewModel(nil, loadTestConfig(t))
+
+	if got := m.renderFindings(); !strings.Contains(got, "No chain to analyze") {
+		t.Errorf("expected an empty-input message, got %q", got)
+	}
+}
+
+func TestFindingsTabIsReachable(t *testing.T) {
+	leaf, intermediate, _ := testChain(t)
+	m := *NewModel([]*certificate.Info{intermediate, leaf}, loadTestConfig(t))
+
+	idx := -1
+	for i, tab := range m.tabs {
+		if tab == "Findings" {
+			idx = i
+			break
+		}
+	}
+	if idx == -1 {
+		t.Fatalf("no Findings tab in %v", m.tabs)
+	}
+
+	m.activeTab = idx
+	if got := m.renderTabContent(80); !strings.Contains(got, "out of order") {
+		t.Errorf("Findings tab selected but its content is not rendered:\n%s", got)
+	}
+}

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -202,8 +202,10 @@ func NewModel(certs []*certificate.Info, cfg *config.Config) *Model {
 		// to come first or the findings it exists to report are gone.
 		chainReport = certificate.AnalyzeChain(rawCerts)
 
-		// Sort the raw certificates
-		sortedRawCerts, _ := certificate.SortChain(rawCerts)
+		// Reuse the sort AnalyzeChain already did: it keeps the result in
+		// Sorted so a caller does not repeat the O(n^2) signature checks on
+		// every model load.
+		sortedRawCerts := chainReport.Sorted
 
 		// Map raw certificates to their Info wrappers for efficient lookup.
 		// Use fingerprint as key, and a slice of wrappers to handle potential duplicates

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -109,12 +109,18 @@ func NewStyles(theme *config.Theme) Styles {
 type Model struct {
 	certificates    []*certificate.Info // Filtered list of certificates
 	allCertificates []*certificate.Info // Original unfiltered list
-	width           int                 // Window width
-	height          int                 // Window height
-	ready           bool                // Whether dimensions are initialized
-	Config          *config.Config      // Application configuration
-	Styles          Styles              // Computed Lip Gloss styles
-	focus           Focus               // Currently focused pane
+
+	// chainReport is how the chain was presented, analyzed before the list was
+	// sorted. It concerns the whole input rather than the selected
+	// certificate, so filtering and searching leave it alone.
+	chainReport *certificate.ChainReport
+
+	width  int            // Window width
+	height int            // Window height
+	ready  bool           // Whether dimensions are initialized
+	Config *config.Config // Application configuration
+	Styles Styles         // Computed Lip Gloss styles
+	focus  Focus          // Currently focused pane
 
 	// Tabs for the right pane
 	tabs      []string
@@ -185,11 +191,17 @@ func NewModel(certs []*certificate.Info, cfg *config.Config) *Model {
 
 	// Sort and validate the certificate chain
 	var sortedCerts []*certificate.Info
+	var chainReport *certificate.ChainReport
 	if len(certs) > 0 {
 		rawCerts := make([]*x509.Certificate, len(certs))
 		for i, c := range certs {
 			rawCerts[i] = c.Certificate
 		}
+		// Analyze before sorting. AnalyzeChain reads the order the chain was
+		// presented in, and everything below reorders it -- so this call has
+		// to come first or the findings it exists to report are gone.
+		chainReport = certificate.AnalyzeChain(rawCerts)
+
 		// Sort the raw certificates
 		sortedRawCerts, _ := certificate.SortChain(rawCerts)
 
@@ -221,7 +233,7 @@ func NewModel(certs []*certificate.Info, cfg *config.Config) *Model {
 		certificate.ValidateChainLinks(sortedCerts)
 	}
 
-	tabs := []string{"Subject", "Issuer", "Validity", "SANs", "Misc"}
+	tabs := []string{"Subject", "Issuer", "Validity", "SANs", "Misc", "Findings"}
 
 	ti := textinput.New()
 	tiStyles := textinput.DefaultDarkStyles()
@@ -250,6 +262,7 @@ func NewModel(certs []*certificate.Info, cfg *config.Config) *Model {
 	return &Model{
 		certificates:    sortedCerts,
 		allCertificates: sortedCerts,
+		chainReport:     chainReport,
 		ready:           false,
 		viewMode:        ViewSplash,
 		focus:           FocusLeft,

--- a/internal/model/view.go
+++ b/internal/model/view.go
@@ -484,9 +484,60 @@ func (m Model) renderTabContent(width int) string {
 		b.WriteString("\n")
 		b.WriteString(m.Styles.SectionTitle.Render("Chain Position") + "\n")
 		b.WriteString(m.renderChainPosition(cert))
+	case "Findings":
+		b.WriteString(m.renderFindings())
 	}
 
 	return lipgloss.NewStyle().Width(width).Render(b.String())
+}
+
+// renderFindings shows how the chain was presented: the missing intermediate,
+// the redundant root, the wrong order. The findings concern the whole chain
+// rather than the selected certificate, which is why this tab reads the same
+// from every row.
+//
+// This is the question `validate` answers and the TUI did not. A chain that
+// verifies can still be served in a way that curl, Go and Java reject, and
+// nothing else on screen says so: the list sorts the chain before drawing it,
+// which is exactly what hides a wrong order or a root that should not have been
+// sent.
+func (m Model) renderFindings() string {
+	var b strings.Builder
+
+	if m.chainReport == nil {
+		return m.Styles.Dimmed.Render("  No chain to analyze")
+	}
+
+	if m.chainReport.OK() {
+		b.WriteString(m.Styles.BadgeValid.Render("  ● Presented correctly") + "\n\n")
+		b.WriteString(m.Styles.Dimmed.Render(
+			"  Every certificate links to the next, the order is leaf-first, " +
+				"and nothing redundant was sent."))
+		return b.String()
+	}
+
+	count := len(m.chainReport.Findings)
+	noun := "problems"
+	if count == 1 {
+		noun = "problem"
+	}
+	b.WriteString(m.Styles.BadgeWarning.Render(fmt.Sprintf("  ▲ %d %s", count, noun)) + "\n")
+
+	for _, finding := range m.chainReport.Findings {
+		b.WriteString("\n")
+		b.WriteString("  " +
+			m.Styles.StatusWarning.Render(finding.Problem.String()) +
+			m.Styles.DetailKey.Render(": ") +
+			m.Styles.DetailValue.Render(finding.Subject) + "\n")
+		b.WriteString(m.Styles.Dimmed.Render("    "+finding.Detail) + "\n")
+		for _, url := range finding.FetchURLs {
+			b.WriteString("    " +
+				m.Styles.DetailKey.Render("fetch from: ") +
+				m.Styles.Highlight.Render(url) + "\n")
+		}
+	}
+
+	return strings.TrimRight(b.String(), "\n")
 }
 
 // renderChainPosition shows the certificate chain as a table, marking the


### PR DESCRIPTION
## What this changes

A `Findings` tab beside `Misc`, reporting how the chain was presented: the missing intermediate, the redundant root, the wrong order, duplicates, strangers in the bundle. Same findings `validate` already produces, from the same `AnalyzeChain`.

```text
┌─ Certificates ──┬─ Subject Issuer Validity SANs Misc Findings ─┐
│ 1. leaf.example │  ▲ 1 problem                                  │
│ 2. Test Int CA  │                                               │
│ 3. Test Root CA │    redundant root: Test Root CA               │
│                 │      a self-signed root was included; clients  │
│                 │      ignore it and trust their own copy, so    │
│                 │      it only adds bytes to every handshake     │
└─────────────────┴───────────────────────────────────────────────┘
```

A clean chain gets a positive statement rather than an empty pane, and no input at all says so.

## Why

This is the question the README leads with, and the TUI was the one surface that could not answer it. `AnalyzeChain` had exactly one caller, `internal/cmd/validate.go` — nothing under `internal/model` touched it.

What the TUI showed before: `ValidateChainLinks` marks a certificate whose issuer is absent, so a missing intermediate appeared as an unlabelled `◆` with its explanation never rendered. A redundant root and a wrong order were invisible, because `NewModel` sorts the chain through `SortChain` before building the list — the sort is correct for navigation and fatal for this question.

Hence the one ordering constraint worth reviewing: `AnalyzeChain` is called on the raw slice **before** `SortChain`, because it reads the order the chain arrived in. Run it afterwards and every chain reports clean, which would be a silent, permanent false negative. `SortChain` allocates a new slice rather than reordering in place, so the presented order survives the call. `TestRenderFindingsAnalyzesBeforeSorting` pins both halves: findings still report `out of order`, and the list is still sorted leaf-first.

The findings are a property of the whole input, not of the selected certificate, so the tab reads the same from every row and the filter and search paths leave it untouched.

## How it was verified

- `make lint` — 0 issues. `make test` — all 6 packages pass. `make vulncheck` did not run locally (no network in this sandbox); no dependency changed.
- New tests build a real three-level chain (root CA, intermediate CA, leaf) rather than a fixture, and assert the four findings that chain can produce: clean, out of order, redundant root, missing issuer. `createTestCertificates` was unusable here — it returns unrelated self-signed certificates, which is itself a finding.
- Rendered the tab strip at widths 100, 60, 40 and 24: six tabs still fit at 100, and below that `renderTabs` collapses to `‹ Subject ›  1/6`, two rows either way, so pane height does not move.

Not in this PR: `docs/index.html` replicates the tab list (`const TABS`) and still shows five. Follow-up rather than an untested addition to the landing page, since the replica would need its own findings rendering.

- [x] `make lint` reports 0 issues
- [x] `make test` passes
- [x] New behaviour has a test, or there is nothing to test