### PR TITLE
feat(model): render the certificate fields that were already parsed

### DIFF
--- a/internal/model/detail_fields_test.go
+++ b/internal/model/detail_fields_test.go
@@ -1,0 +1,148 @@
+package model
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"math/big"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kanywst/y509/pkg/certificate"
+)
+
+// richCert carries the fields the detail tabs used to drop on the floor, all of
+// them named fields on x509.Certificate that were parsed and then never shown.
+func richCert(t *testing.T) *x509.Certificate {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generating a key: %v", err)
+	}
+
+	policy, err := x509.ParseOID("2.23.140.1.2.1")
+	if err != nil {
+		t.Fatalf("parsing the policy OID: %v", err)
+	}
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(42),
+		Subject: pkix.Name{
+			CommonName:         "rich.example.com",
+			Organization:       []string{"Example Ltd"},
+			OrganizationalUnit: []string{"Platform"},
+			Country:            []string{"JP"},
+			Province:           []string{"Tokyo"},
+			Locality:           []string{"Chiyoda"},
+			StreetAddress:      []string{"1-1 Nowhere"},
+			PostalCode:         []string{"100-0001"},
+			ExtraNames: []pkix.AttributeTypeAndValue{
+				{Type: asn1.ObjectIdentifier{2, 5, 4, 97}, Value: "NTRJP-99999"},
+			},
+		},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+		BasicConstraintsValid: true,
+		SubjectKeyId:          []byte{0xde, 0xad, 0xbe, 0xef},
+		AuthorityKeyId:        []byte{0xfe, 0xed, 0xfa, 0xce},
+		IssuingCertificateURL: []string{"http://ca.example.com/issuer.crt"},
+		OCSPServer:            []string{"http://ocsp.example.com"},
+		CRLDistributionPoints: []string{"http://crl.example.com/ca.crl"},
+		Policies:              []x509.OID{policy},
+		URIs:                  []*url.URL{{Scheme: "spiffe", Host: "example", Path: "/workload"}},
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("creating the certificate: %v", err)
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatalf("parsing the certificate: %v", err)
+	}
+	return cert
+}
+
+// tabContent renders one named tab for the given certificate.
+func tabContent(t *testing.T, cert *x509.Certificate, tab string) string {
+	t.Helper()
+
+	m := *NewModel([]*certificate.Info{{Certificate: cert}}, loadTestConfig(t))
+	idx := -1
+	for i, name := range m.tabs {
+		if name == tab {
+			idx = i
+			break
+		}
+	}
+	if idx == -1 {
+		t.Fatalf("no %q tab in %v", tab, m.tabs)
+	}
+	m.activeTab = idx
+	return m.renderTabContent(100)
+}
+
+func TestMiscTabShowsTheFieldsAlreadyParsed(t *testing.T) {
+	got := tabContent(t, richCert(t), "Misc")
+
+	// Every one of these was parsed by crypto/x509 and then not rendered.
+	for _, want := range []string{
+		"Version", "v3",
+		"SKI", "de:ad:be:ef",
+		"AKI", "fe:ed:fa:ce",
+		"Key Usage", "digitalSignature", "keyEncipherment",
+		"Ext Key Usage", "serverAuth", "clientAuth",
+		"Constraints", "CA: no",
+		"CA Issuers", "http://ca.example.com/issuer.crt",
+		"OCSP", "http://ocsp.example.com",
+		"CRL", "http://crl.example.com/ca.crl",
+		"domain validated",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("Misc tab does not show %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestSANsTabShowsURIs(t *testing.T) {
+	got := tabContent(t, richCert(t), "SANs")
+
+	if !strings.Contains(got, "spiffe://example/workload") {
+		t.Errorf("SANs tab drops URI SANs:\n%s", got)
+	}
+	// The fallback line has to go when there is something to show.
+	if strings.Contains(got, "No SANs present") {
+		t.Errorf("SANs tab claims there are no SANs while rendering one:\n%s", got)
+	}
+}
+
+func TestSubjectTabShowsUnnamedDNAttributes(t *testing.T) {
+	got := tabContent(t, richCert(t), "Subject")
+
+	for _, want := range []string{"Street", "Postal Code", "organizationIdentifier", "NTRJP-99999"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("Subject tab does not show %q:\n%s", want, got)
+		}
+	}
+}
+
+// TestIssuerTabMatchesSubject pins the asymmetry that used to exist: Issuer
+// rendered CN, Organization and Country only, so a self-signed certificate
+// showed different DNs on two tabs that hold the same attributes.
+func TestIssuerTabMatchesSubject(t *testing.T) {
+	cert := richCert(t) // self-signed, so issuer and subject are identical
+	subject := tabContent(t, cert, "Subject")
+	issuer := tabContent(t, cert, "Issuer")
+
+	if subject != issuer {
+		t.Errorf("Subject and Issuer render the same DN differently:\n--- subject ---\n%s\n--- issuer ---\n%s", subject, issuer)
+	}
+}

--- a/internal/model/view.go
+++ b/internal/model/view.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"crypto/x509/pkix"
 	"fmt"
 	"strings"
 	"time"
@@ -395,16 +396,12 @@ func (m Model) renderTabContent(width int) string {
 
 	switch m.tabs[m.activeTab] {
 	case "Subject":
-		kv("CN", cert.Certificate.Subject.CommonName)
-		kv("Organization", strings.Join(cert.Certificate.Subject.Organization, ", "))
-		kv("OU", strings.Join(cert.Certificate.Subject.OrganizationalUnit, ", "))
-		kv("Country", strings.Join(cert.Certificate.Subject.Country, ", "))
-		kv("Province", strings.Join(cert.Certificate.Subject.Province, ", "))
-		kv("Locality", strings.Join(cert.Certificate.Subject.Locality, ", "))
+		renderDN(kv, cert.Certificate.Subject)
 	case "Issuer":
-		kv("CN", cert.Certificate.Issuer.CommonName)
-		kv("Organization", strings.Join(cert.Certificate.Issuer.Organization, ", "))
-		kv("Country", strings.Join(cert.Certificate.Issuer.Country, ", "))
+		// The same fields as Subject, deliberately: an issuer DN carries the
+		// same attributes, and showing fewer of them made two tabs disagree
+		// about what a distinguished name is.
+		renderDN(kv, cert.Certificate.Issuer)
 	case "Validity":
 		notBefore := cert.Certificate.NotBefore.Format("2006-01-02 15:04:05 MST")
 		notAfter := cert.Certificate.NotAfter.Format("2006-01-02 15:04:05 MST")
@@ -469,6 +466,10 @@ func (m Model) renderTabContent(width int) string {
 			kv("Email", email)
 			hasSANs = true
 		}
+		for _, uri := range cert.Certificate.URIs {
+			kv("URI", uri.String())
+			hasSANs = true
+		}
 		if !hasSANs {
 			b.WriteString(m.Styles.Dimmed.Render("  No SANs present"))
 		}
@@ -476,9 +477,51 @@ func (m Model) renderTabContent(width int) string {
 		kv("Serial", cert.Certificate.SerialNumber.String())
 		kv("SHA256", groupHex(certificate.FormatFingerprint(cert.Certificate)))
 		kv("Sig Algo", cert.Certificate.SignatureAlgorithm.String())
+		kv("Version", fmt.Sprintf("v%d", cert.Certificate.Version))
+		kv("SKI", groupHex(fmt.Sprintf("%x", cert.Certificate.SubjectKeyId)))
+		kv("AKI", groupHex(fmt.Sprintf("%x", cert.Certificate.AuthorityKeyId)))
 		b.WriteString("\n")
 		b.WriteString(m.Styles.SectionTitle.Render("Public Key") + "\n")
 		kvLines(certificate.FormatPublicKey(cert.Certificate))
+
+		// What the certificate is allowed to be used for. A client that
+		// refuses a certificate for its usage says nothing about which bit
+		// offended, so both extensions are worth having on screen.
+		if ku, eku := certificate.KeyUsageNames(cert.Certificate), certificate.ExtKeyUsageNames(cert.Certificate); len(ku) > 0 || len(eku) > 0 || certificate.BasicConstraints(cert.Certificate) != "" {
+			b.WriteString("\n")
+			b.WriteString(m.Styles.SectionTitle.Render("Usage") + "\n")
+			kv("Key Usage", strings.Join(ku, ", "))
+			kv("Ext Key Usage", strings.Join(eku, ", "))
+			kv("Constraints", certificate.BasicConstraints(cert.Certificate))
+		}
+
+		// Where a client would go for the issuer or for revocation. These are
+		// the URLs behind the "missing intermediate" finding, so seeing them
+		// here closes the loop with the Findings tab.
+		aia := cert.Certificate.IssuingCertificateURL
+		ocsp := cert.Certificate.OCSPServer
+		crl := cert.Certificate.CRLDistributionPoints
+		if len(aia) > 0 || len(ocsp) > 0 || len(crl) > 0 {
+			b.WriteString("\n")
+			b.WriteString(m.Styles.SectionTitle.Render("Endpoints") + "\n")
+			for _, url := range aia {
+				kv("CA Issuers", url)
+			}
+			for _, url := range ocsp {
+				kv("OCSP", url)
+			}
+			for _, url := range crl {
+				kv("CRL", url)
+			}
+		}
+
+		if policies := certificate.PolicyOIDs(cert.Certificate); len(policies) > 0 {
+			b.WriteString("\n")
+			b.WriteString(m.Styles.SectionTitle.Render("Policies") + "\n")
+			for _, policy := range policies {
+				kv("", policy)
+			}
+		}
 
 		// Chain position visualization
 		b.WriteString("\n")
@@ -538,6 +581,28 @@ func (m Model) renderFindings() string {
 	}
 
 	return strings.TrimRight(b.String(), "\n")
+}
+
+// renderDN writes a distinguished name through the tab's aligned key/value
+// renderer, including the attributes pkix.Name has no field for. Those come
+// last: they are the unusual ones, and an EV certificate carries several.
+func renderDN(kv func(key, value string), name pkix.Name) {
+	kv("CN", name.CommonName)
+	kv("Organization", strings.Join(name.Organization, ", "))
+	kv("OU", strings.Join(name.OrganizationalUnit, ", "))
+	kv("Country", strings.Join(name.Country, ", "))
+	kv("Province", strings.Join(name.Province, ", "))
+	kv("Locality", strings.Join(name.Locality, ", "))
+	kv("Street", strings.Join(name.StreetAddress, ", "))
+	kv("Postal Code", strings.Join(name.PostalCode, ", "))
+	kv("Serial", name.SerialNumber)
+
+	// The extras go in the value column whole, rather than through the key
+	// column: an attribute name like organizationIdentifier is wider than the
+	// key column and would be split mid-word.
+	for _, extra := range certificate.ExtraDNAttributes(name) {
+		kv("", extra)
+	}
 }
 
 // renderChainPosition shows the certificate chain as a table, marking the

--- a/pkg/certificate/describe.go
+++ b/pkg/certificate/describe.go
@@ -1,0 +1,221 @@
+package certificate
+
+import (
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"fmt"
+)
+
+// This file turns the parts of an x509.Certificate that are bitmasks, OIDs or
+// unnamed DN attributes into something a view can print. It lives here rather
+// than in the renderer so the model never has to reason about X.509 encodings.
+
+// keyUsageNames pairs each KeyUsage bit with the name RFC 5280 gives it.
+// contentCommitment is listed under its modern name, since "nonRepudiation" was
+// renamed precisely because it promised more than the bit delivers.
+var keyUsageNames = []struct {
+	bit  x509.KeyUsage
+	name string
+}{
+	{x509.KeyUsageDigitalSignature, "digitalSignature"},
+	{x509.KeyUsageContentCommitment, "contentCommitment"},
+	{x509.KeyUsageKeyEncipherment, "keyEncipherment"},
+	{x509.KeyUsageDataEncipherment, "dataEncipherment"},
+	{x509.KeyUsageKeyAgreement, "keyAgreement"},
+	{x509.KeyUsageCertSign, "keyCertSign"},
+	{x509.KeyUsageCRLSign, "cRLSign"},
+	{x509.KeyUsageEncipherOnly, "encipherOnly"},
+	{x509.KeyUsageDecipherOnly, "decipherOnly"},
+}
+
+// KeyUsageNames lists the key usages the certificate asserts, in the order the
+// extension defines them. Empty when the extension is absent.
+func KeyUsageNames(cert *x509.Certificate) []string {
+	if cert == nil || cert.KeyUsage == 0 {
+		return nil
+	}
+
+	names := make([]string, 0, len(keyUsageNames))
+	for _, ku := range keyUsageNames {
+		if cert.KeyUsage&ku.bit != 0 {
+			names = append(names, ku.name)
+		}
+	}
+	return names
+}
+
+var extKeyUsageNames = map[x509.ExtKeyUsage]string{
+	x509.ExtKeyUsageAny:                            "any",
+	x509.ExtKeyUsageServerAuth:                     "serverAuth",
+	x509.ExtKeyUsageClientAuth:                     "clientAuth",
+	x509.ExtKeyUsageCodeSigning:                    "codeSigning",
+	x509.ExtKeyUsageEmailProtection:                "emailProtection",
+	x509.ExtKeyUsageIPSECEndSystem:                 "ipsecEndSystem",
+	x509.ExtKeyUsageIPSECTunnel:                    "ipsecTunnel",
+	x509.ExtKeyUsageIPSECUser:                      "ipsecUser",
+	x509.ExtKeyUsageTimeStamping:                   "timeStamping",
+	x509.ExtKeyUsageOCSPSigning:                    "OCSPSigning",
+	x509.ExtKeyUsageMicrosoftServerGatedCrypto:     "microsoftServerGatedCrypto",
+	x509.ExtKeyUsageNetscapeServerGatedCrypto:      "netscapeServerGatedCrypto",
+	x509.ExtKeyUsageMicrosoftCommercialCodeSigning: "microsoftCommercialCodeSigning",
+	x509.ExtKeyUsageMicrosoftKernelCodeSigning:     "microsoftKernelCodeSigning",
+}
+
+// ExtKeyUsageNames lists the extended key usages, including the ones Go does
+// not recognise: those come back as bare OIDs rather than being dropped, since
+// an unknown EKU can be the reason a client refuses the certificate.
+func ExtKeyUsageNames(cert *x509.Certificate) []string {
+	if cert == nil {
+		return nil
+	}
+
+	names := make([]string, 0, len(cert.ExtKeyUsage)+len(cert.UnknownExtKeyUsage))
+	for _, eku := range cert.ExtKeyUsage {
+		if name, ok := extKeyUsageNames[eku]; ok {
+			names = append(names, name)
+		} else {
+			names = append(names, fmt.Sprintf("unrecognized (%d)", eku))
+		}
+	}
+	for _, oid := range cert.UnknownExtKeyUsage {
+		names = append(names, oid.String())
+	}
+
+	if len(names) == 0 {
+		return nil
+	}
+	return names
+}
+
+// BasicConstraints describes the CA bit and any path length limit, or an empty
+// string when the extension is absent.
+//
+// The distinction between "no limit" and "zero" matters: pathLen 0 means this CA
+// may issue end-entity certificates but no further CAs, which is what a
+// technically constrained subordinate looks like.
+func BasicConstraints(cert *x509.Certificate) string {
+	if cert == nil || !cert.BasicConstraintsValid {
+		return ""
+	}
+
+	if !cert.IsCA {
+		return "CA: no"
+	}
+	switch {
+	case cert.MaxPathLenZero:
+		return "CA: yes, pathLen 0 (may not issue further CAs)"
+	case cert.MaxPathLen > 0:
+		return fmt.Sprintf("CA: yes, pathLen %d", cert.MaxPathLen)
+	default:
+		return "CA: yes, no pathLen limit"
+	}
+}
+
+// cabfPolicyNames names the CA/Browser Forum validation-level policy OIDs,
+// which say how the subject was vetted -- the one policy OID a reader is likely
+// to want in words.
+var cabfPolicyNames = map[string]string{
+	"2.23.140.1.1":   "CABF extended validation",
+	"2.23.140.1.2.1": "CABF domain validated",
+	"2.23.140.1.2.2": "CABF organization validated",
+	"2.23.140.1.2.3": "CABF individual validated",
+	"2.5.29.32.0":    "anyPolicy",
+}
+
+// PolicyOIDs lists the certificate policies, naming the CA/Browser Forum
+// validation levels and leaving everything else as an OID.
+//
+// Policies is read in preference to PolicyIdentifiers. Both are populated when
+// a certificate is parsed, but Policies is the field that is not deprecated,
+// and it is the only one CreateCertificate still writes -- so a certificate
+// minted by current Go and read back through the older field alone would look
+// as though it asserted no policy at all.
+func PolicyOIDs(cert *x509.Certificate) []string {
+	if cert == nil {
+		return nil
+	}
+
+	oids := make([]string, 0, len(cert.Policies))
+	for _, policy := range cert.Policies {
+		oids = append(oids, policy.String())
+	}
+	if len(oids) == 0 {
+		for _, oid := range cert.PolicyIdentifiers { //nolint:staticcheck // the fallback is the point
+			oids = append(oids, oid.String())
+		}
+	}
+
+	names := make([]string, 0, len(oids))
+	for _, oid := range oids {
+		if name, ok := cabfPolicyNames[oid]; ok {
+			names = append(names, fmt.Sprintf("%s (%s)", name, oid))
+		} else {
+			names = append(names, oid)
+		}
+	}
+
+	if len(names) == 0 {
+		return nil
+	}
+	return names
+}
+
+// namedDNAttributes are the attribute OIDs pkix.Name already exposes as fields,
+// so ExtraDNAttributes can report everything else.
+var namedDNAttributes = map[string]bool{
+	"2.5.4.3":  true, // commonName
+	"2.5.4.5":  true, // serialNumber
+	"2.5.4.6":  true, // countryName
+	"2.5.4.7":  true, // localityName
+	"2.5.4.8":  true, // stateOrProvinceName
+	"2.5.4.9":  true, // streetAddress
+	"2.5.4.10": true, // organizationName
+	"2.5.4.11": true, // organizationalUnitName
+	"2.5.4.17": true, // postalCode
+}
+
+// extraDNAttributeNames names the attributes seen often enough in the WebPKI to
+// be worth words rather than an arc.
+var extraDNAttributeNames = map[string]string{
+	"2.5.4.4":                     "surname",
+	"2.5.4.12":                    "title",
+	"2.5.4.42":                    "givenName",
+	"2.5.4.15":                    "businessCategory",
+	"2.5.4.97":                    "organizationIdentifier",
+	"1.2.840.113549.1.9.1":        "emailAddress",
+	"0.9.2342.19200300.100.1.25":  "domainComponent",
+	"1.3.6.1.4.1.311.60.2.1.1":    "jurisdictionLocality",
+	"1.3.6.1.4.1.311.60.2.1.2":    "jurisdictionStateOrProvince",
+	"1.3.6.1.4.1.311.60.2.1.3":    "jurisdictionCountry",
+	"1.3.6.1.4.1.311.60.2.1.3.10": "jurisdictionCountry",
+}
+
+// ExtraDNAttributes lists the distinguished name attributes that pkix.Name has
+// no field for, as "name: value" pairs.
+//
+// pkix.Name.Names carries every attribute that was parsed, including these, so
+// they are already in hand -- a renderer that reads only the named fields drops
+// a subject's businessCategory or organizationIdentifier without saying so.
+func ExtraDNAttributes(name pkix.Name) []string {
+	var out []string
+	for _, atv := range name.Names {
+		oid := atv.Type.String()
+		if namedDNAttributes[oid] {
+			continue
+		}
+
+		label := oid
+		if named, ok := extraDNAttributeNames[oid]; ok {
+			label = named
+		}
+
+		// A non-string value (an ASN.1 type Go did not decode into a string)
+		// is reported as present rather than guessed at.
+		value, ok := atv.Value.(string)
+		if !ok {
+			value = fmt.Sprintf("(%T, not decoded)", atv.Value)
+		}
+		out = append(out, fmt.Sprintf("%s: %s", label, value))
+	}
+	return out
+}

--- a/pkg/certificate/describe_test.go
+++ b/pkg/certificate/describe_test.go
@@ -1,0 +1,244 @@
+package certificate
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"math/big"
+	"net/url"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+)
+
+// describeCert signs template so the fields under test come back through a real
+// parse rather than being read off the struct that was written. An extension
+// that does not survive encoding would otherwise pass.
+func describeCert(t *testing.T, template *x509.Certificate) *x509.Certificate {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generating a key: %v", err)
+	}
+	if template.SerialNumber == nil {
+		template.SerialNumber = big.NewInt(1)
+	}
+	if template.NotAfter.IsZero() {
+		template.NotBefore = time.Now().Add(-time.Hour)
+		template.NotAfter = time.Now().Add(time.Hour)
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("creating the certificate: %v", err)
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatalf("parsing the certificate: %v", err)
+	}
+	return cert
+}
+
+func mustOID(t *testing.T, s string) x509.OID {
+	t.Helper()
+	oid, err := x509.ParseOID(s)
+	if err != nil {
+		t.Fatalf("parsing the OID %q: %v", s, err)
+	}
+	return oid
+}
+
+func TestKeyUsageNames(t *testing.T) {
+	cert := describeCert(t, &x509.Certificate{
+		Subject:  pkix.Name{CommonName: "usage"},
+		KeyUsage: x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+	})
+
+	got := KeyUsageNames(cert)
+	want := []string{"digitalSignature", "keyCertSign"}
+	if !slices.Equal(got, want) {
+		t.Errorf("KeyUsageNames() = %v, want %v", got, want)
+	}
+
+	// Order follows the extension's bit order, not the order they were set.
+	if got[0] != "digitalSignature" {
+		t.Errorf("usages are out of RFC 5280 order: %v", got)
+	}
+}
+
+func TestKeyUsageNamesWithoutTheExtension(t *testing.T) {
+	cert := describeCert(t, &x509.Certificate{Subject: pkix.Name{CommonName: "none"}})
+
+	if got := KeyUsageNames(cert); got != nil {
+		t.Errorf("KeyUsageNames() = %v, want nil when the extension is absent", got)
+	}
+	if got := KeyUsageNames(nil); got != nil {
+		t.Errorf("KeyUsageNames(nil) = %v, want nil", got)
+	}
+}
+
+// TestExtKeyUsageNamesKeepsUnknownOIDs is the point of the helper: Go parses an
+// EKU it does not recognise into UnknownExtKeyUsage, and dropping those would
+// hide the reason a client refused the certificate.
+func TestExtKeyUsageNamesKeepsUnknownOIDs(t *testing.T) {
+	exotic := asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 99999, 1}
+	cert := describeCert(t, &x509.Certificate{
+		Subject:            pkix.Name{CommonName: "eku"},
+		ExtKeyUsage:        []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		UnknownExtKeyUsage: []asn1.ObjectIdentifier{exotic},
+	})
+
+	got := ExtKeyUsageNames(cert)
+	if !slices.Contains(got, "serverAuth") {
+		t.Errorf("ExtKeyUsageNames() = %v, want it to name serverAuth", got)
+	}
+	if !slices.Contains(got, exotic.String()) {
+		t.Errorf("ExtKeyUsageNames() = %v, want it to carry the unknown OID %s", got, exotic)
+	}
+}
+
+func TestBasicConstraints(t *testing.T) {
+	tests := []struct {
+		name     string
+		template *x509.Certificate
+		want     string
+	}{
+		{
+			name:     "absent extension says nothing",
+			template: &x509.Certificate{Subject: pkix.Name{CommonName: "no constraints"}},
+			want:     "",
+		},
+		{
+			name: "an end-entity certificate",
+			template: &x509.Certificate{
+				Subject:               pkix.Name{CommonName: "leaf"},
+				BasicConstraintsValid: true,
+			},
+			want: "CA: no",
+		},
+		{
+			name: "a CA with no path length limit",
+			template: &x509.Certificate{
+				Subject:               pkix.Name{CommonName: "ca"},
+				BasicConstraintsValid: true,
+				IsCA:                  true,
+			},
+			want: "CA: yes, no pathLen limit",
+		},
+		{
+			name: "a CA that may not issue further CAs",
+			template: &x509.Certificate{
+				Subject:               pkix.Name{CommonName: "constrained ca"},
+				BasicConstraintsValid: true,
+				IsCA:                  true,
+				MaxPathLenZero:        true,
+			},
+			want: "CA: yes, pathLen 0 (may not issue further CAs)",
+		},
+		{
+			name: "a CA with a path length of one",
+			template: &x509.Certificate{
+				Subject:               pkix.Name{CommonName: "ca1"},
+				BasicConstraintsValid: true,
+				IsCA:                  true,
+				MaxPathLen:            1,
+			},
+			want: "CA: yes, pathLen 1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := BasicConstraints(describeCert(t, tt.template)); got != tt.want {
+				t.Errorf("BasicConstraints() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestPolicyOIDsNamesTheValidationLevel builds the fixture through Policies,
+// not PolicyIdentifiers: current Go ignores the deprecated field when creating
+// a certificate, so a fixture written the old way asserts no policy at all.
+func TestPolicyOIDsNamesTheValidationLevel(t *testing.T) {
+	dv := mustOID(t, "2.23.140.1.2.1")
+	other := mustOID(t, "1.3.6.1.4.1.44947.1.1.1")
+	cert := describeCert(t, &x509.Certificate{
+		Subject:  pkix.Name{CommonName: "policies"},
+		Policies: []x509.OID{dv, other},
+	})
+
+	got := PolicyOIDs(cert)
+	if len(got) != 2 {
+		t.Fatalf("PolicyOIDs() = %v, want two entries", got)
+	}
+	if !strings.Contains(got[0], "domain validated") || !strings.Contains(got[0], dv.String()) {
+		t.Errorf("PolicyOIDs()[0] = %q, want the CABF name and the OID", got[0])
+	}
+	// An OID with no well-known name stays an OID rather than being dropped.
+	if got[1] != other.String() {
+		t.Errorf("PolicyOIDs()[1] = %q, want the bare OID %s", got[1], other)
+	}
+}
+
+// TestExtraDNAttributes covers what pkix.Name has no field for. These are
+// already parsed into Names, so a renderer reading only the named fields drops
+// them without saying anything.
+func TestExtraDNAttributes(t *testing.T) {
+	cert := describeCert(t, &x509.Certificate{
+		Subject: pkix.Name{
+			CommonName:   "extras.example.com",
+			Organization: []string{"Example Ltd"},
+			ExtraNames: []pkix.AttributeTypeAndValue{
+				{Type: asn1.ObjectIdentifier{2, 5, 4, 15}, Value: "Private Organization"},
+				{Type: asn1.ObjectIdentifier{2, 5, 4, 97}, Value: "NTRGB-12345"},
+				{Type: asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 99999, 7}, Value: "custom"},
+			},
+		},
+	})
+
+	got := ExtraDNAttributes(cert.Subject)
+	joined := strings.Join(got, "\n")
+
+	for _, want := range []string{
+		"businessCategory: Private Organization",
+		"organizationIdentifier: NTRGB-12345",
+		"1.3.6.1.4.1.99999.7: custom",
+	} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("ExtraDNAttributes() = %v, want it to include %q", got, want)
+		}
+	}
+
+	// The attributes pkix.Name already exposes must not be repeated here, or
+	// every DN would list its CN twice.
+	if strings.Contains(joined, "extras.example.com") || strings.Contains(joined, "Example Ltd") {
+		t.Errorf("ExtraDNAttributes() repeated a named field: %v", got)
+	}
+}
+
+// TestDescribeURISANsSurviveAParse guards the field the SANs tab was missing:
+// a URI-only certificate has to come back with URIs populated, or the tab has
+// nothing to render.
+func TestDescribeURISANsSurviveAParse(t *testing.T) {
+	cert := describeCert(t, &x509.Certificate{
+		Subject: pkix.Name{CommonName: "workload"},
+		URIs:    []*url.URL{{Scheme: "spiffe", Host: "example", Path: "/workload"}},
+	})
+
+	if len(cert.URIs) != 1 {
+		t.Fatalf("parsed certificate carries %d URI SANs, want 1", len(cert.URIs))
+	}
+	if got := cert.URIs[0].String(); got != "spiffe://example/workload" {
+		t.Errorf("URI SAN = %q, want the SPIFFE ID", got)
+	}
+	// And nothing else claims it: this is exactly the certificate that used to
+	// report "No SANs present".
+	if len(cert.DNSNames)+len(cert.IPAddresses)+len(cert.EmailAddresses) != 0 {
+		t.Error("fixture is not URI-only, so it does not test the gap")
+	}
+}


### PR DESCRIPTION
## What this changes

The detail tabs now show what `crypto/x509` already parsed:

- **Misc** gains the X.509 version, SKI and AKI, a `Usage` section (key usage, extended key usage, basic constraints), an `Endpoints` section (AIA `caIssuers`, OCSP, CRL distribution points) and the policy OIDs.
- **Issuer** renders the same attributes as **Subject**, plus street, postal code and DN serial on both, plus the attributes `pkix.Name` has no field for.
- **SANs** renders `cert.URIs`.

New `pkg/certificate/describe.go` holds the parts that need decoding rather than printing.

## Why

Everything added here was parsed and then thrown away. Three of them were actively misleading:

- A URI-only certificate reported **"No SANs present"**. A SPIFFE ID is an identity, and the tab said the certificate had none.
- `Issuer` rendered CN, Organization and Country while `Subject` rendered six attributes, so a self-signed certificate displayed two different distinguished names for the same name. The test asserts the two tabs now render identically for one.
- The AIA `caIssuers` URL is what the "missing issuer" finding tells you to fetch, and it was nowhere on screen.

The decoding lives in `pkg/certificate` because it is X.509 encoding work, not layout: a key usage bitmask, an EKU list where Go parks unrecognised OIDs in a separate field, the `pathLen 0` case (a CA that may not issue further CAs, which is what a technically constrained subordinate looks like), and the DN attributes carried in `pkix.Name.Names` with no field of their own.

One thing worth knowing, since it cost a failing test to find: **`Policies` is read in preference to `PolicyIdentifiers`**. Both are populated when a certificate is parsed, but current Go ignores the deprecated field when *creating* one, so a fixture built the old way asserts no policy at all and a reader of the old field alone would report the same.

Also a display fix found the same way: an attribute name like `organizationIdentifier` is wider than the key column and was being split mid-word, so the unnamed DN attributes render in the value column whole.

## How it was verified

- `make lint` — 0 issues. `make test` — all 6 packages pass.
- `pkg/certificate/describe_test.go` signs and re-parses every fixture rather than reading fields off the struct it wrote, so an extension that does not survive encoding cannot pass. Covers the usage bitmask order, an unknown EKU OID being kept rather than dropped, all five basic-constraints cases, the CABF policy naming, and the named-versus-extra DN split.
- `internal/model/detail_fields_test.go` renders each tab for a certificate carrying all of it and asserts the strings appear, including `Subject` and `Issuer` matching for a self-signed certificate.

- [x] `make lint` reports 0 issues
- [x] `make test` passes
- [x] New behaviour has a test, or there is nothing to test