### PR TITLE
fix(certificate): one unreadable block no longer blanks the bundle

### DIFF
--- a/internal/cmd/partial_test.go
+++ b/internal/cmd/partial_test.go
@@ -1,0 +1,103 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// bundleWithAnUnreadableBlock writes a chain whose second CERTIFICATE block
+// holds bytes crypto/x509 refuses. The armour is valid, so this is the shape of
+// the real case: a well-formed block carrying something Go cannot read.
+func bundleWithAnUnreadableBlock(t *testing.T) string {
+	t.Helper()
+
+	chain := newTestChain(t)
+	corrupt := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: []byte{0x30, 0x03, 0x02, 0x01, 0x00},
+	})
+
+	var bundle bytes.Buffer
+	bundle.Write(chain.LeafPEM)
+	bundle.Write(corrupt)
+	bundle.Write(chain.ChainPEM[len(chain.LeafPEM):])
+
+	path := filepath.Join(t.TempDir(), "bundle.pem")
+	if err := os.WriteFile(path, bundle.Bytes(), 0o600); err != nil {
+		t.Fatalf("writing the bundle: %v", err)
+	}
+	return path
+}
+
+// TestValidateReportsUnreadableBlocks is the visible half of the fix: skipping
+// a block silently would leave a trusted verdict looking like the whole story.
+func TestValidateReportsUnreadableBlocks(t *testing.T) {
+	path := bundleWithAnUnreadableBlock(t)
+
+	out, err := runRoot(t, "validate", path)
+	// The chain is anchored at its own untrusted root, so a non-zero exit is
+	// expected; the note is what this test is about.
+	if err == nil {
+		t.Log("validate exited 0")
+	}
+
+	if !strings.Contains(out, "could not be parsed") {
+		t.Errorf("validate did not mention the unreadable block:\n%s", out)
+	}
+	if !strings.Contains(out, "Note:") {
+		t.Errorf("the notice is not marked as one:\n%s", out)
+	}
+}
+
+func TestValidateJSONCarriesUnreadableBlocks(t *testing.T) {
+	path := bundleWithAnUnreadableBlock(t)
+
+	out, _ := runRoot(t, "validate", path, "--json")
+
+	var report struct {
+		Chain    []map[string]any `json:"chain"`
+		Unparsed []struct {
+			Index int    `json:"index"`
+			Bytes int    `json:"bytes"`
+			Error string `json:"error"`
+		} `json:"unparsed"`
+	}
+	// A decoder rather than Unmarshal: the chain is self-anchored, so validate
+	// exits non-zero and cobra appends its error after the report. Reading one
+	// value is what a consumer piping into jq does too.
+	if err := json.NewDecoder(strings.NewReader(out)).Decode(&report); err != nil {
+		t.Fatalf("the JSON does not parse: %v\n%s", err, out)
+	}
+
+	if len(report.Unparsed) != 1 {
+		t.Fatalf("report lists %d unparsed blocks, want 1:\n%s", len(report.Unparsed), out)
+	}
+	if report.Unparsed[0].Index != 1 {
+		t.Errorf("unparsed block index = %d, want 1", report.Unparsed[0].Index)
+	}
+	if report.Unparsed[0].Bytes == 0 || report.Unparsed[0].Error == "" {
+		t.Errorf("unparsed entry is missing its size or error: %+v", report.Unparsed[0])
+	}
+	// The readable certificates still have to be there.
+	if len(report.Chain) != 2 {
+		t.Errorf("report holds %d chain entries, want the 2 that parsed", len(report.Chain))
+	}
+}
+
+// TestValidateJSONOmitsUnparsedWhenEverythingParsed keeps the common case
+// byte-identical for existing consumers.
+func TestValidateJSONOmitsUnparsedWhenEverythingParsed(t *testing.T) {
+	chain := newTestChain(t)
+	path := write(t, "chain.pem", chain.ChainPEM)
+
+	out, _ := runRoot(t, "validate", path, "--json")
+
+	if strings.Contains(out, "unparsed") {
+		t.Errorf("the report carries an unparsed key for a clean bundle:\n%s", out)
+	}
+}

--- a/internal/cmd/partial_test.go
+++ b/internal/cmd/partial_test.go
@@ -62,7 +62,7 @@ func TestValidateJSONCarriesUnreadableBlocks(t *testing.T) {
 	var report struct {
 		Chain    []map[string]any `json:"chain"`
 		Unparsed []struct {
-			Index int    `json:"index"`
+			Block int    `json:"block"`
 			Bytes int    `json:"bytes"`
 			Error string `json:"error"`
 		} `json:"unparsed"`
@@ -77,8 +77,13 @@ func TestValidateJSONCarriesUnreadableBlocks(t *testing.T) {
 	if len(report.Unparsed) != 1 {
 		t.Fatalf("report lists %d unparsed blocks, want 1:\n%s", len(report.Unparsed), out)
 	}
-	if report.Unparsed[0].Index != 1 {
-		t.Errorf("unparsed block index = %d, want 1", report.Unparsed[0].Index)
+	if report.Unparsed[0].Block != 1 {
+		t.Errorf("unparsed block = %d, want 1", report.Unparsed[0].Block)
+	}
+	// The key must not be "index": chain[].index is a contiguous counter over
+	// what parsed, so one name for two numbering spaces would mislead.
+	if strings.Contains(out, `"index": 1,`) && !strings.Contains(out, `"block": 1`) {
+		t.Error("the unparsed entry reuses the chain's index key")
 	}
 	if report.Unparsed[0].Bytes == 0 || report.Unparsed[0].Error == "" {
 		t.Errorf("unparsed entry is missing its size or error: %+v", report.Unparsed[0])

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 
 	tea "charm.land/bubbletea/v2"
@@ -126,6 +127,10 @@ func init() {
 
 		// Create and run the TUI
 		model := model.NewModel(source.Certs, cfg)
+		// The list can only show what parsed, so the header has to admit it
+		// when that was not everything. Nothing may be printed here: stdout
+		// belongs to the TUI.
+		model.SetNotice(unparsedSummary(source.Unparsed))
 		p := tea.NewProgram(model)
 
 		if _, err := p.Run(); err != nil {
@@ -157,6 +162,10 @@ type input struct {
 	// stdin. It carries the negotiated version, the cipher suite and whether
 	// OCSP was stapled, none of which the certificates themselves record.
 	Conn *certificate.ConnectResult
+	// Unparsed are the CERTIFICATE blocks that could not be read. They are
+	// carried rather than dropped so a command can say the input held more
+	// than it is showing.
+	Unparsed []certificate.ParseFailure
 }
 
 // loadInput decides where the certificates come from: a live server, a file, or
@@ -194,11 +203,44 @@ func loadInput(cmd *cobra.Command, args []string) (*input, error) {
 		}
 	}
 
-	certs, err := certificate.LoadCertificates(target)
+	certs, unparsed, err := certificate.LoadCertificatesReport(target)
 	if err != nil {
 		return nil, err
 	}
-	return &input{Certs: certs}, nil
+	return &input{Certs: certs, Unparsed: unparsed}, nil
+}
+
+// describeUnparsed summarises the blocks that could not be read, for a command
+// that has to admit the input held more than it is showing. Empty when
+// everything parsed.
+func describeUnparsed(failures []certificate.ParseFailure) string {
+	if len(failures) == 0 {
+		return ""
+	}
+
+	noun := "certificates"
+	if len(failures) == 1 {
+		noun = "certificate"
+	}
+	positions := make([]string, 0, len(failures))
+	for _, f := range failures {
+		positions = append(positions, strconv.Itoa(f.Block))
+	}
+
+	return fmt.Sprintf("%d %s in the input could not be parsed (at %s): %v",
+		len(failures), noun, strings.Join(positions, ", "), failures[0].Err)
+}
+
+// unparsedSummary is the short form for the TUI header, where there is one line
+// and it sits beside the certificate count.
+func unparsedSummary(failures []certificate.ParseFailure) string {
+	if len(failures) == 0 {
+		return ""
+	}
+	if len(failures) == 1 {
+		return "1 unreadable certificate in the input"
+	}
+	return fmt.Sprintf("%d unreadable certificates in the input", len(failures))
 }
 
 // connectFromFlags fetches a chain from a live server.

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -89,6 +89,14 @@ says nothing at all about how the chain was served.`,
 				fmt.Println()
 				fmt.Println(presentation)
 			}
+
+			// The verdict above is about the certificates that could be read.
+			// Say so when that was not all of them, or a trusted chain would
+			// look like the whole story.
+			if notice := describeUnparsed(source.Unparsed); notice != "" {
+				fmt.Println()
+				fmt.Printf("Note: %s\n", notice)
+			}
 		}
 
 		logger.Log.Info("Certificate chain validation result",
@@ -116,6 +124,8 @@ func writeJSONReport(w io.Writer, source *input, report *certificate.ChainReport
 	// Nil for a file or stdin, which leaves the object out entirely rather
 	// than reporting a handshake that never happened.
 	out.Connection = certificate.NewJSONConnection(source.Conn)
+	// Nil when everything parsed, which leaves the key out entirely.
+	out.Unparsed = certificate.NewJSONUnparsed(source.Unparsed)
 
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -143,12 +143,26 @@ type Model struct {
 	keys keyMap
 	help help.Model
 
+	// notice is a one-line warning about the input itself, shown in the
+	// header. It exists for what the certificates cannot say: that the file
+	// held blocks y509 could not read.
+	notice string
+
 	// Internal state for logic
 	detailField  string
 	detailValue  string
 	searchQuery  string
 	filterActive bool
 	filterType   string
+}
+
+// SetNotice sets a one-line warning about the input, shown in the header.
+//
+// It is a setter rather than a constructor argument because it is about the
+// input rather than the certificates, and only the command that read the file
+// knows about it.
+func (m *Model) SetNotice(notice string) {
+	m.notice = notice
 }
 
 // SetDimensions sets the width and height of the model (for testing only)

--- a/internal/model/notice_test.go
+++ b/internal/model/notice_test.go
@@ -1,0 +1,30 @@
+package model
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestHeaderShowsTheInputNotice covers the TUI half of a partially readable
+// bundle. The list can only show what parsed, so without this the certificates
+// that were skipped leave no trace anywhere on screen.
+func TestHeaderShowsTheInputNotice(t *testing.T) {
+	m := NewModel(createTestCertificates(2), loadTestConfig(t))
+	m.SetDimensions(120, 40)
+	m.SetReady(true)
+
+	if got := m.renderHeader(); strings.Contains(got, "unreadable") {
+		t.Fatalf("header carries a notice that was never set:\n%s", got)
+	}
+
+	m.SetNotice("1 unreadable certificate in the input")
+	got := m.renderHeader()
+
+	if !strings.Contains(got, "1 unreadable certificate in the input") {
+		t.Errorf("header does not show the notice:\n%s", got)
+	}
+	// The certificate count stays: the notice is an addition, not a takeover.
+	if !strings.Contains(got, "2 certs") {
+		t.Errorf("header lost the certificate count:\n%s", got)
+	}
+}

--- a/internal/model/view.go
+++ b/internal/model/view.go
@@ -106,6 +106,13 @@ func (m Model) renderHeader() string {
 		crumbs = append(crumbs, m.Styles.DetailValue.Render(truncateText(cn, 30)))
 	}
 
+	// A warning about the input itself goes last, in the warning colour: the
+	// list can only show what parsed, so nothing else on screen would say that
+	// the file held more.
+	if m.notice != "" {
+		crumbs = append(crumbs, m.Styles.StatusWarning.Render("▲ "+m.notice))
+	}
+
 	sep := m.Styles.BreadcrumbSep.String()
 	breadcrumb := strings.Join(crumbs, sep)
 

--- a/pkg/certificate/certificate.go
+++ b/pkg/certificate/certificate.go
@@ -75,15 +75,37 @@ const (
 
 // Info holds certificate data and metadata
 type Info struct {
-	Certificate      *x509.Certificate
+	Certificate *x509.Certificate
+	// Index is the certificate's position in the input, counting only
+	// CERTIFICATE blocks and counting from zero. A block that failed to parse
+	// still consumes a number -- it is reported as a ParseFailure with the same
+	// Index -- so these stay aligned with the file even when the slice is
+	// shorter than the bundle.
 	Index            int
 	Label            string
 	ValidationStatus ValidationStatus
 	ValidationError  error
 }
 
-// LoadCertificates loads certificates from a file or stdin
+// LoadCertificatesReport loads certificates from a file or stdin and also
+// reports the CERTIFICATE blocks that could not be parsed.
+func LoadCertificatesReport(filename string) ([]*Info, []ParseFailure, error) {
+	data, err := readInput(filename)
+	if err != nil {
+		return nil, nil, err
+	}
+	return ParseCertificatesReport(data)
+}
+
+// LoadCertificates loads certificates from a file or stdin. Unparsable blocks
+// are skipped; use LoadCertificatesReport to see them.
 func LoadCertificates(filename string) ([]*Info, error) {
+	certs, _, err := LoadCertificatesReport(filename)
+	return certs, err
+}
+
+// readInput reads the whole input, from a file or from stdin.
+func readInput(filename string) ([]byte, error) {
 	var input io.Reader
 	if filename == "" {
 		input = os.Stdin
@@ -112,7 +134,7 @@ func LoadCertificates(filename string) ([]*Info, error) {
 		return nil, fmt.Errorf("empty input")
 	}
 
-	return ParseCertificates(data)
+	return data, nil
 }
 
 // SortChain sorts certificates into valid chains [Leaf, Intermediate, Root]
@@ -355,34 +377,71 @@ func ExportChain(certs []*x509.Certificate, filename string) error {
 	return nil
 }
 
+// ParseFailure is a CERTIFICATE block that could not be parsed.
+//
+// It is reported rather than being allowed to abort the whole input: a bundle
+// holding one certificate this version of Go declines -- a valid certificate
+// using an algorithm crypto/x509 has not caught up with, say -- must not hide
+// the certificates around it.
+type ParseFailure struct {
+	// Block is the position of the CERTIFICATE block in the input, counting
+	// from zero and counting only CERTIFICATE blocks.
+	Block int
+	// Raw is the DER that failed to parse, kept so a caller can report its
+	// size or write it out for inspection.
+	Raw []byte
+	// Err is what crypto/x509 made of it.
+	Err error
+}
+
 // ParseCertificates extracts certificates from a PEM bundle or from raw DER.
 //
 // PEM is tried first. If the input holds no PEM armour at all it is treated as
 // DER, which is what Windows and most CAs hand out as .der / .cer, and what
 // y509's own export writes when asked for DER.
+//
+// Blocks that fail to parse are skipped. Use ParseCertificatesReport to see
+// them; an error comes back only when nothing could be parsed at all.
 func ParseCertificates(data []byte) ([]*Info, error) {
-	certs, sawPEM, err := parsePEMCertificates(data)
-	if err != nil {
-		return nil, err
-	}
+	certs, _, err := ParseCertificatesReport(data)
+	return certs, err
+}
+
+// ParseCertificatesReport parses the input and also reports the CERTIFICATE
+// blocks it could not read.
+func ParseCertificatesReport(data []byte) ([]*Info, []ParseFailure, error) {
+	certs, failures, sawPEM := parsePEMCertificates(data)
 	if len(certs) > 0 {
-		return certs, nil
+		return certs, failures, nil
+	}
+
+	// Nothing parsed, but something was there: report what went wrong with the
+	// first block rather than the generic "no certificates found".
+	if len(failures) > 0 {
+		logger.Error("No CERTIFICATE block could be parsed", zap.Error(failures[0].Err))
+		return nil, failures, fmt.Errorf("failed to parse certificate %d: %w", failures[0].Block, failures[0].Err)
 	}
 
 	if sawPEM {
 		// The input is PEM, it just holds no certificates -- a lone private key
 		// file, say. Saying "no certificates found" is right, but say why.
 		logger.Error("PEM input contains no CERTIFICATE blocks")
-		return nil, fmt.Errorf("no certificates found in input: the PEM data contains no CERTIFICATE blocks")
+		return nil, nil, fmt.Errorf("no certificates found in input: the PEM data contains no CERTIFICATE blocks")
 	}
 
-	return parseDERCertificates(data)
+	certs, err := parseDERCertificates(data)
+	return certs, nil, err
 }
 
 // parsePEMCertificates walks the PEM blocks in data. sawPEM reports whether any
-// PEM block at all was present, which tells ParseCertificates whether it is
-// worth retrying the input as DER.
-func parsePEMCertificates(data []byte) (certs []*Info, sawPEM bool, err error) {
+// PEM block at all was present, which tells ParseCertificatesReport whether it
+// is worth retrying the input as DER.
+//
+// A block that fails to parse is recorded and skipped rather than ending the
+// walk. Aborting meant a bundle of good/bad/good showed nothing at all, and the
+// certificate most likely to fail is a valid one whose algorithm this Go does
+// not know yet -- so the failure has to cost one row, not the whole file.
+func parsePEMCertificates(data []byte) (certs []*Info, failures []ParseFailure, sawPEM bool) {
 	rest := data
 	index := 0
 
@@ -396,8 +455,16 @@ func parsePEMCertificates(data []byte) (certs []*Info, sawPEM bool, err error) {
 		if block.Type == "CERTIFICATE" {
 			crt, err := x509.ParseCertificate(block.Bytes)
 			if err != nil {
-				logger.Error("Failed to parse certificate", zap.Error(err))
-				return nil, sawPEM, fmt.Errorf("failed to parse certificate %d: %w", index, err)
+				logger.Error("Failed to parse certificate",
+					zap.Int("block", index), zap.Int("bytes", len(block.Bytes)), zap.Error(err))
+				failures = append(failures, ParseFailure{Block: index, Raw: block.Bytes, Err: err})
+				// The block still counts: a caller comparing what it asked for
+				// against what it got needs the positions to line up with the
+				// file, and "certificate 2 is unreadable" has to mean the third
+				// one in the bundle.
+				index++
+				rest = remaining
+				continue
 			}
 
 			certs = append(certs, &Info{
@@ -407,14 +474,14 @@ func parsePEMCertificates(data []byte) (certs []*Info, sawPEM bool, err error) {
 			})
 			// Count certificates, not PEM blocks: a bundle may also carry a
 			// private key, DH parameters, or a CRL, and those must not consume
-			// a number. Index has to stay equal to the slice position.
+			// a number.
 			index++
 		}
 
 		rest = remaining
 	}
 
-	return certs, sawPEM, nil
+	return certs, failures, sawPEM
 }
 
 // parseDERCertificates reads the input as raw DER. x509.ParseCertificates

--- a/pkg/certificate/partial_test.go
+++ b/pkg/certificate/partial_test.go
@@ -180,8 +180,8 @@ func TestNewJSONUnparsedIsAbsentWhenEverythingParsed(t *testing.T) {
 	if len(got) != 1 {
 		t.Fatalf("NewJSONUnparsed returned %d entries, want 1", len(got))
 	}
-	if got[0].Index != 3 || got[0].Bytes != 3 || got[0].Error != "bad" {
-		t.Errorf("NewJSONUnparsed()[0] = %+v, want index 3, 3 bytes and the error text", got[0])
+	if got[0].Block != 3 || got[0].Bytes != 3 || got[0].Error != "bad" {
+		t.Errorf("NewJSONUnparsed()[0] = %+v, want block 3, 3 bytes and the error text", got[0])
 	}
 }
 

--- a/pkg/certificate/partial_test.go
+++ b/pkg/certificate/partial_test.go
@@ -1,0 +1,190 @@
+package certificate
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// partialCert signs a throwaway self-signed certificate with the given common
+// name, so a bundle can be assembled from real DER.
+func partialCert(t *testing.T, cn string) *x509.Certificate {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generating a key: %v", err)
+	}
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: cn},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("creating the certificate: %v", err)
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatalf("parsing the certificate: %v", err)
+	}
+	return cert
+}
+
+// corruptBlock is a CERTIFICATE block holding bytes that are not a certificate.
+// The armour is valid, so pem.Decode hands it over and x509 is what refuses --
+// which is the shape of the real case: a well-formed block carrying something
+// this version of Go cannot read.
+func corruptBlock() []byte {
+	return pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: []byte{0x30, 0x03, 0x02, 0x01, 0x00},
+	})
+}
+
+// TestParseKeepsGoingPastAnUnreadableBlock is the bug: one certificate Go
+// declines used to abort the whole input, so a bundle of good/bad/good showed
+// nothing at all.
+func TestParseKeepsGoingPastAnUnreadableBlock(t *testing.T) {
+	first := partialCert(t, "first")
+	second := partialCert(t, "second")
+
+	var bundle bytes.Buffer
+	bundle.Write(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: first.Raw}))
+	bundle.Write(corruptBlock())
+	bundle.Write(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: second.Raw}))
+
+	certs, failures, err := ParseCertificatesReport(bundle.Bytes())
+	if err != nil {
+		t.Fatalf("ParseCertificatesReport: %v", err)
+	}
+
+	if len(certs) != 2 {
+		t.Fatalf("parsed %d certificates, want the two that are readable", len(certs))
+	}
+	if cn := certs[0].Certificate.Subject.CommonName; cn != "first" {
+		t.Errorf("first certificate is %q, want %q", cn, "first")
+	}
+	if cn := certs[1].Certificate.Subject.CommonName; cn != "second" {
+		t.Errorf("second certificate is %q, want %q", cn, "second")
+	}
+
+	if len(failures) != 1 {
+		t.Fatalf("reported %d failures, want 1", len(failures))
+	}
+	if failures[0].Block != 1 {
+		t.Errorf("failure is at block %d, want 1", failures[0].Block)
+	}
+	if len(failures[0].Raw) == 0 {
+		t.Error("failure carries no raw DER, so a caller cannot report its size")
+	}
+	if failures[0].Err == nil {
+		t.Error("failure carries no error")
+	}
+}
+
+// TestParseIndexesStayAlignedWithTheInput pins the numbering: a skipped block
+// still consumes a position, so "certificate 2" means the third one in the file
+// whether or not the second could be read.
+func TestParseIndexesStayAlignedWithTheInput(t *testing.T) {
+	first := partialCert(t, "first")
+	second := partialCert(t, "second")
+
+	var bundle bytes.Buffer
+	bundle.Write(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: first.Raw}))
+	bundle.Write(corruptBlock())
+	bundle.Write(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: second.Raw}))
+
+	certs, failures, err := ParseCertificatesReport(bundle.Bytes())
+	if err != nil {
+		t.Fatalf("ParseCertificatesReport: %v", err)
+	}
+
+	if certs[0].Index != 0 {
+		t.Errorf("first certificate has Index %d, want 0", certs[0].Index)
+	}
+	if certs[1].Index != 2 {
+		t.Errorf("second readable certificate has Index %d, want 2: the skipped block keeps its place", certs[1].Index)
+	}
+	if failures[0].Block != certs[1].Index-1 {
+		t.Errorf("failure block %d does not sit between the two certificates", failures[0].Block)
+	}
+}
+
+// TestParseStillFailsWhenNothingIsReadable keeps the useful error: skipping is
+// for a bundle that holds something, not for an input that holds nothing.
+func TestParseStillFailsWhenNothingIsReadable(t *testing.T) {
+	certs, failures, err := ParseCertificatesReport(corruptBlock())
+
+	if err == nil {
+		t.Fatal("parsing succeeded for an input with no readable certificate")
+	}
+	if len(certs) != 0 {
+		t.Errorf("parsed %d certificates from an unreadable input", len(certs))
+	}
+	if len(failures) != 1 {
+		t.Errorf("reported %d failures, want 1", len(failures))
+	}
+	// The message has to name the block, or the only clue is "it failed".
+	if !strings.Contains(err.Error(), "certificate 0") {
+		t.Errorf("error = %q, want it to name the block that failed", err)
+	}
+}
+
+func TestLoadCertificatesSkipsUnreadableBlocks(t *testing.T) {
+	cert := partialCert(t, "only")
+
+	var bundle bytes.Buffer
+	bundle.Write(corruptBlock())
+	bundle.Write(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw}))
+
+	path := t.TempDir() + "/bundle.pem"
+	if err := os.WriteFile(path, bundle.Bytes(), 0o600); err != nil {
+		t.Fatalf("writing the bundle: %v", err)
+	}
+
+	certs, failures, err := LoadCertificatesReport(path)
+	if err != nil {
+		t.Fatalf("LoadCertificatesReport: %v", err)
+	}
+	if len(certs) != 1 || len(failures) != 1 {
+		t.Fatalf("got %d certificates and %d failures, want 1 and 1", len(certs), len(failures))
+	}
+
+	// The compatibility wrapper must behave the same, minus the report.
+	plain, err := LoadCertificates(path)
+	if err != nil {
+		t.Fatalf("LoadCertificates: %v", err)
+	}
+	if len(plain) != 1 {
+		t.Errorf("LoadCertificates returned %d certificates, want 1", len(plain))
+	}
+}
+
+func TestNewJSONUnparsedIsAbsentWhenEverythingParsed(t *testing.T) {
+	if got := NewJSONUnparsed(nil); got != nil {
+		t.Errorf("NewJSONUnparsed(nil) = %v, want nil so the key is omitted", got)
+	}
+
+	got := NewJSONUnparsed([]ParseFailure{{Block: 3, Raw: []byte{1, 2, 3}, Err: errForTest("bad")}})
+	if len(got) != 1 {
+		t.Fatalf("NewJSONUnparsed returned %d entries, want 1", len(got))
+	}
+	if got[0].Index != 3 || got[0].Bytes != 3 || got[0].Error != "bad" {
+		t.Errorf("NewJSONUnparsed()[0] = %+v, want index 3, 3 bytes and the error text", got[0])
+	}
+}
+
+type errForTest string
+
+func (e errForTest) Error() string { return string(e) }

--- a/pkg/certificate/report.go
+++ b/pkg/certificate/report.go
@@ -45,13 +45,19 @@ type JSONReport struct {
 
 // JSONUnparsed is one CERTIFICATE block that failed to parse.
 //
-// The error text is the parser's own and is not a stable contract; Index and
-// Bytes are what a consumer can act on -- the position in the input, and enough
+// The error text is the parser's own and is not a stable contract; Block and
+// Bytes are what a consumer can act on -- where in the input it was, and enough
 // to tell an empty block from a truncated certificate.
 type JSONUnparsed struct {
-	// Index is the block's position in the input, counting only CERTIFICATE
-	// blocks from zero, so it lines up with the chain entries around it.
-	Index int `json:"index"`
+	// Block is the position in the input, counting every CERTIFICATE block
+	// from zero including the ones that failed.
+	//
+	// It is deliberately not called "index": Chain[].Index is a contiguous
+	// counter over the certificates that parsed, so for an input of
+	// good/bad/good the chain holds indexes 0 and 1 while this block is 1, and
+	// the two ones are different certificates. Two numbering spaces with one
+	// name would be worse than two names.
+	Block int `json:"block"`
 	// Bytes is the size of the DER that could not be parsed.
 	Bytes int `json:"bytes"`
 	// Error is what crypto/x509 reported.
@@ -69,7 +75,7 @@ func NewJSONUnparsed(failures []ParseFailure) []JSONUnparsed {
 
 	out := make([]JSONUnparsed, 0, len(failures))
 	for _, f := range failures {
-		entry := JSONUnparsed{Index: f.Block, Bytes: len(f.Raw)}
+		entry := JSONUnparsed{Block: f.Block, Bytes: len(f.Raw)}
 		if f.Err != nil {
 			entry.Error = f.Err.Error()
 		}

--- a/pkg/certificate/report.go
+++ b/pkg/certificate/report.go
@@ -36,6 +36,46 @@ type JSONReport struct {
 	// for a file or stdin, where there was no handshake and every field would
 	// be an invention.
 	Connection *JSONConnection `json:"connection,omitempty"`
+	// Unparsed lists the CERTIFICATE blocks the input held that could not be
+	// read, so a consumer can tell "this chain is fine" from "this chain is
+	// fine as far as it could be read". Absent when everything parsed, which
+	// keeps the common case byte-identical for existing consumers.
+	Unparsed []JSONUnparsed `json:"unparsed,omitempty"`
+}
+
+// JSONUnparsed is one CERTIFICATE block that failed to parse.
+//
+// The error text is the parser's own and is not a stable contract; Index and
+// Bytes are what a consumer can act on -- the position in the input, and enough
+// to tell an empty block from a truncated certificate.
+type JSONUnparsed struct {
+	// Index is the block's position in the input, counting only CERTIFICATE
+	// blocks from zero, so it lines up with the chain entries around it.
+	Index int `json:"index"`
+	// Bytes is the size of the DER that could not be parsed.
+	Bytes int `json:"bytes"`
+	// Error is what crypto/x509 reported.
+	Error string `json:"error"`
+}
+
+// NewJSONUnparsed translates parse failures for the report. Returns nil for
+// none, so the field is omitted rather than marshalled as an empty array: here
+// "absent" and "empty" mean the same thing, and absent keeps the output
+// unchanged for the overwhelming majority of runs.
+func NewJSONUnparsed(failures []ParseFailure) []JSONUnparsed {
+	if len(failures) == 0 {
+		return nil
+	}
+
+	out := make([]JSONUnparsed, 0, len(failures))
+	for _, f := range failures {
+		entry := JSONUnparsed{Index: f.Block, Bytes: len(f.Raw)}
+		if f.Err != nil {
+			entry.Error = f.Err.Error()
+		}
+		out = append(out, entry)
+	}
+	return out
 }
 
 // JSONConnection is what the handshake itself revealed, as opposed to what the


### PR DESCRIPTION
## What this changes

A CERTIFICATE block that fails to parse is skipped and reported, instead of aborting the whole input. Before: a bundle of good/bad/good rendered **nothing** and exited 1.

The skip is visible on every surface — the TUI header, the `validate` text report, and a new `unparsed` array in the JSON (omitted when everything parsed, so a clean run is byte-identical for existing consumers).

`ParseCertificatesReport` and `LoadCertificatesReport` return the failures; `ParseCertificates` and `LoadCertificates` keep their signatures.

## Why

The certificate most likely to fail here is not a corrupt one. It is a **valid** certificate whose algorithm this Go does not know yet — SLH-DSA is standardised in RFC 9909 and `crypto/x509` cannot read it. All-or-nothing is the wrong trade for that: the cost of a block y509 cannot parse should be that block, not the file.

An error still comes back when nothing parsed at all, and it names the block rather than saying "no certificates found".

Two things worth reviewing:

- **Skipping quietly would be its own bug.** A trusted verdict on a bundle that was only partly read looks like the whole story, so the note goes everywhere the certificates go. A CI job consuming JSON can now tell "this chain is fine" from "this chain is fine as far as it could be read".
- **`Info.Index` now means the position in the input, not in the slice.** A skipped block keeps its number, so "certificate 2" is the third one in the file whether or not the second could be read, and the JSON `unparsed[].index` lines up with the `chain[].index` entries around it. The field had no readers outside the parser (`grep` for `.Index` finds only `strings.Index` and the list's own cursor), and the old invariant is unstateable once the slice can be shorter than the bundle.

Deliberately **not** here: a placeholder row in the list for the unreadable certificate. That needs `Info.Certificate == nil` handling in the delegate, every detail tab, the fingerprint map, `ValidateChainLinks`, `SortChain` and the JSON — a nil dereference in any of them is a crashed TUI. Worth doing as its own change.

## How it was verified

- `make lint` — 0 issues. `make test` — all 6 packages pass.
- The fixtures use a **valid PEM envelope around bytes x509 refuses**, which is the real shape: `pem.Decode` hands the block over and the certificate parser is what declines.
- Covered: good/bad/good parses both readable certificates; the index alignment; an all-unreadable input still failing with the block named; `LoadCertificates` behaving like `LoadCertificatesReport` minus the report; the `validate` note; `unparsed` present with index, size and error; `unparsed` absent for a clean bundle; and the TUI header showing the warning without losing the certificate count.

- [x] `make lint` reports 0 issues
- [x] `make test` passes
- [x] New behaviour has a test, or there is nothing to test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Validation now continues when certificate bundles contain unreadable certificate blocks.
  * Text output identifies unreadable blocks with a clear note.
  * JSON reports include the affected block index, byte count, and parsing error while retaining readable certificates.
  * The interactive interface displays warnings for unreadable certificates.
  * Certificate details now include additional distinguished-name attributes, URIs, key identifiers, usage constraints, endpoints, and policy information.
* **Bug Fixes**
  * Clean certificate bundles omit unnecessary unreadable-certificate details from JSON output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->